### PR TITLE
chore: add basic GitHub ISSUE_TEMPLATEs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,38 +1,29 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
-labels: ''
+title: Abbreviated error message or problem statement
+labels: bug
 assignees: ''
 
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+
+What did you expect? and what happened instead?
 
 **To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+How might we do it again to see/experience the problem?
+(describe in numbered point steps, if possible)
+1. ...
+2. ...
+3. ... error
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
-
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
-
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+**Device / Machine (please complete):**
+ - OS/Device: [ex: Windows 11, macOS Sequoia, Android 15]
+ - Arch: [ex: M1, AMD64]
+ - Version [ex: v1.0.5]
 
 **Additional context**
+
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,28 @@
+---
+name: Documentation
+about: Ask or create a 'How does' or 'How to'.
+title: 'question: How does x do y? OR doc: How to do x with y, etc'
+labels: documentation
+assignees: ''
+
+---
+
+Ask your question, or add some quick, helpful notes or article-style documentation below.
+
+# The General Idea
+
+## Section 1
+
+1. some steps
+   ```sh
+   # code block
+   ```
+
+## Section 2
+
+- some notes
+   ```json
+   {
+       "config": {}
+   }
+   ```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,24 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
-labels: ''
+title: Concise idea description
+labels: enhancement
 assignees: ''
 
 ---
 
 **Is your feature request related to a problem? Please describe.**
+
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
 **Describe the solution you'd like**
+
 A clear and concise description of what you want to happen.
 
 **Describe alternatives you've considered**
+
 A clear and concise description of any alternative solutions or features you've considered.
 
 **Additional context**
+
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/security.md
+++ b/.github/ISSUE_TEMPLATE/security.md
@@ -1,0 +1,22 @@
+---
+name: Security
+about: Ask a security-related question or report a vulnerability
+title: Short summary of your question or concern
+labels: question
+assignees: ''
+
+---
+
+# Have a implementation-specific report?
+
+STOP
+
+**PRIVATELY** reach out to report a practical attack or disclose an imminent vulnerability:
+- security@therootcompany.com
+
+See also:
+- https://github.com/therootcompany/.github/SECURITY.md
+
+# Have a general question or concern?
+
+If you have a general question about what approaches and security measures are taken for fairly public, general, or otherwise well-understood risks, ask away.


### PR DESCRIPTION
I went through the "Set up templates" flow.
- modified the Bug report to be more streamlined, sequential
- add mostly stock Feature request 
- add Documentation template for notes, questions, and articles
- add Security template to redirect potential vulns to private message

<img width="1192" alt="Screenshot 2025-02-03 at 8 53 53 PM" src="https://github.com/user-attachments/assets/6cf10d5f-eb4d-4fcb-beb6-4feb30f1c472" />
