### PR TITLE
fix: backup storage volume by default

### DIFF
--- a/bin/proxmox-create
+++ b/bin/proxmox-create
@@ -381,7 +381,7 @@ fn_help() { (
 ); }
 
 fn_version() { (
-    echo "proxmox-create v0.2024.08.12"
+    echo "proxmox-create v0.2025.02.10"
 ); }
 
 fn_show_next() { (

--- a/bin/proxmox-create
+++ b/bin/proxmox-create
@@ -206,7 +206,7 @@ fn_create_lxc() { (
             --data-urlencode "ssh-public-keys=${my_pubkeys}" \
             --data-urlencode "ostemplate=${my_tmpl_vol}:${my_os_tmpl}" \
             --data-urlencode "rootfs=${my_fs_pool}:${my_fs_size},mountoptions=${my_fs_opts}" \
-            --data-urlencode "mp0=${my_mp0_pool}:${my_mp0_size},mp=${my_mp0_mnt},mountoptions=${my_mp0_opts}" \
+            --data-urlencode "mp0=${my_mp0_pool}:${my_mp0_size},mp=${my_mp0_mnt},mountoptions=${my_mp0_opts},backup=1" \
             --data-urlencode "cores=${my_cores}" \
             --data-urlencode "cpulimit=${my_cpulimit}" \
             --data-urlencode "memory=${my_memory}" \


### PR DESCRIPTION
We want to enable backups of storage volumes by default.

Volumes for blockchain data and similar will need to be disabled manually.