### PR TITLE
feat: prefer PROXMOX_BASE_URL over PROXMOX_HOST

### DIFF
--- a/bin/proxmox-create
+++ b/bin/proxmox-create
@@ -20,7 +20,7 @@ PROXMOX_ID_PREFIX="${PROXMOX_ID_PREFIX:-${PROXMOX_ID_VLAN:-}}"
 PROXMOX_ID_START="${PROXMOX_ID_START:-51}"
 
 if test -n "${g_show_help:-}" ||
-   test -z "${PROXMOX_HOST:-}" ||
+   { test -z "${PROXMOX_BASE_URL:-}" && test -z "${PROXMOX_HOST:-}"; } ||
 
    # Private Networking
    # VNET and BRIDGE checked above
@@ -65,7 +65,18 @@ if test -n "${g_show_help:-}" ||
 fi
 
 my_auth="Authorization: PVEAPIToken=${PROXMOX_TOKEN_ID}=${PROXMOX_TOKEN_SECRET}"
-my_base_url="https://${PROXMOX_HOST}/api2/json"
+if test -n "${PROXMOX_BASE_URL:-}"; then
+   case "${PROXMOX_BASE_URL}" in
+      http*) ;;
+      *)
+         echo "Error: PROXMOX_BASE_URL must begin with 'http'" >&2
+         exit 1
+         ;;
+   esac
+   my_base_url="${PROXMOX_BASE_URL%/}"
+else
+   my_base_url="https://${PROXMOX_HOST}/api2/json"
+fi
 my_curl="curl --max-time 15 --fail-with-body -sSL"
 
 fn_discover() { (
@@ -476,7 +487,7 @@ main() { (
       # shellcheck disable=SC2012
       ls -l ~/.config/proxmox-sh/current.env | sed 's;.* /;/;'
 
-      echo "PROXMOX_HOST=${PROXMOX_HOST:-}"
+      echo "PROXMOX_BASE_URL=${my_base_url}"
       echo "PROXMOX_TARGET_NODE=${PROXMOX_TARGET_NODE:-}"
       echo "PROXMOX_ID_PREFIX=${PROXMOX_ID_PREFIX:-}"
       if test -n "${PROXMOX_VNET:-}" || test -z "${PROXMOX_BRIDGE:-}"; then

--- a/example.proxmox-sh.env
+++ b/example.proxmox-sh.env
@@ -1,6 +1,6 @@
 # shellcheck disable=SC2034
 
-PROXMOX_HOST='192.168.0.10:8006'
+PROXMOX_BASE_URL='https://192.168.0.10:8006/api2/json'
 
 # Private Networking
 # either use VNET

--- a/provision-lxc
+++ b/provision-lxc
@@ -11,12 +11,12 @@ if test -e .env.secret; then
     . .env.secret || true
 fi
 
-if test -z "${PROXMOX_HOST:-}" ||
+if { test -z "${PROXMOX_BASE_URL:-}" && test -z "${PROXMOX_HOST:-}"; } ||
     test -z "${PROXMOX_TOKEN_ID:-}" ||
     test -z "${PROXMOX_TOKEN_SECRET:-}" ||
     test -z "${PROXMOX_TARGET_NODE:-}"; then
     echo "./.env or ./.env.secret should contain values like these:"
-    echo "    PROXMOX_HOST='10.x.x.x:8006'"
+    echo "    PROXMOX_BASE_URL='https://10.x.x.x:8006/api2/json'"
     echo "    PROXMOX_TARGET_NODE='pve1'"
     echo "    PROXMOX_TOKEN_ID='<user>@<strategy>!<token-name>'"
     echo "    PROXMOX_TOKEN_SECRET='00000000-0000-4000-8000-000000000000'"
@@ -24,7 +24,15 @@ if test -z "${PROXMOX_HOST:-}" ||
 fi
 
 my_auth="Authorization: PVEAPIToken=${PROXMOX_TOKEN_ID}=${PROXMOX_TOKEN_SECRET}"
-my_base_url="https://${PROXMOX_HOST}/api2/json"
+if test -n "${PROXMOX_BASE_URL:-}"; then
+    case "${PROXMOX_BASE_URL}" in
+        http*) ;;
+        *) echo "Error: PROXMOX_BASE_URL must begin with 'http'" >&2; exit 1 ;;
+    esac
+    my_base_url="${PROXMOX_BASE_URL%/}"
+else
+    my_base_url="https://${PROXMOX_HOST}/api2/json"
+fi
 my_curl="curl -k --max-time 15 --proto =https --tlsv1.2 -fsS"
 
 fn_lxc_last_id() { (

--- a/proxmox-destroy
+++ b/proxmox-destroy
@@ -11,12 +11,12 @@ if test -e .env.secret; then
     . ./.env.secret || true
 fi
 
-if test -z "${PROXMOX_HOST:-}" ||
+if { test -z "${PROXMOX_BASE_URL:-}" && test -z "${PROXMOX_HOST:-}"; } ||
     test -z "${PROXMOX_TOKEN_ID:-}" ||
     test -z "${PROXMOX_TOKEN_SECRET:-}" ||
     test -z "${PROXMOX_TARGET_NODE:-}"; then
     echo "./.env or ./.env.secret should contain values like these:"
-    echo "    PROXMOX_HOST='10.x.x.x:8006'"
+    echo "    PROXMOX_BASE_URL='https://10.x.x.x:8006/api2/json'"
     echo "    PROXMOX_TARGET_NODE='pve1'"
     echo "    PROXMOX_TOKEN_ID='<user>@<strategy>!<token-name>'"
     echo "    PROXMOX_TOKEN_SECRET='00000000-0000-4000-8000-000000000000'"
@@ -24,7 +24,15 @@ if test -z "${PROXMOX_HOST:-}" ||
 fi
 
 my_auth="Authorization: PVEAPIToken=${PROXMOX_TOKEN_ID}=${PROXMOX_TOKEN_SECRET}"
-my_base_url="https://${PROXMOX_HOST}/api2/json"
+if test -n "${PROXMOX_BASE_URL:-}"; then
+    case "${PROXMOX_BASE_URL}" in
+        http*) ;;
+        *) echo "Error: PROXMOX_BASE_URL must begin with 'http'" >&2; exit 1 ;;
+    esac
+    my_base_url="${PROXMOX_BASE_URL%/}"
+else
+    my_base_url="https://${PROXMOX_HOST}/api2/json"
+fi
 my_curl="curl -k --max-time 15 -fsSL"
 
 fn_destroy() { (

--- a/proxmox-shutdown
+++ b/proxmox-shutdown
@@ -11,12 +11,12 @@ if test -e .env.secret; then
     . .env.secret || true
 fi
 
-if test -z "${PROXMOX_HOST:-}" ||
+if { test -z "${PROXMOX_BASE_URL:-}" && test -z "${PROXMOX_HOST:-}"; } ||
     test -z "${PROXMOX_TOKEN_ID:-}" ||
     test -z "${PROXMOX_TOKEN_SECRET:-}" ||
     test -z "${PROXMOX_TARGET_NODE:-}"; then
     echo "./.env or ./.env.secret should contain values like these:"
-    echo "    PROXMOX_HOST='10.x.x.x:8006'"
+    echo "    PROXMOX_BASE_URL='https://10.x.x.x:8006/api2/json'"
     echo "    PROXMOX_TARGET_NODE='pve1'"
     echo "    PROXMOX_TOKEN_ID='<user>@<strategy>!<token-name>'"
     echo "    PROXMOX_TOKEN_SECRET='00000000-0000-4000-8000-000000000000'"
@@ -24,7 +24,15 @@ if test -z "${PROXMOX_HOST:-}" ||
 fi
 
 my_auth="Authorization: PVEAPIToken=${PROXMOX_TOKEN_ID}=${PROXMOX_TOKEN_SECRET}"
-my_base_url="https://${PROXMOX_HOST}:8006/api2/json"
+if test -n "${PROXMOX_BASE_URL:-}"; then
+    case "${PROXMOX_BASE_URL}" in
+        http*) ;;
+        *) echo "Error: PROXMOX_BASE_URL must begin with 'http'" >&2; exit 1 ;;
+    esac
+    my_base_url="${PROXMOX_BASE_URL%/}"
+else
+    my_base_url="https://${PROXMOX_HOST}:8006/api2/json"
+fi
 my_curl="curl -k --max-time 15 -fsSL"
 
 fn_shutdown() { (


### PR DESCRIPTION
## Summary

- Replaces `PROXMOX_HOST` (which hard-coded `https://` scheme and `/api2/json` path) with `PROXMOX_BASE_URL`, giving callers full control over scheme, host, port, and path
- Validates that `PROXMOX_BASE_URL` begins with `http`; trims any trailing slash
- `PROXMOX_HOST` is still accepted as a fallback for backwards compatibility
- Updated all four scripts (`proxmox-create`, `proxmox-destroy`, `proxmox-shutdown`, `provision-lxc`) and `example.proxmox-sh.env`

## Test plan

- [ ] Set `PROXMOX_BASE_URL='https://10.x.x.x:8006/api2/json'` (no trailing slash) — should work as before
- [ ] Set `PROXMOX_BASE_URL='https://10.x.x.x:8006/api2/json/'` (trailing slash) — slash should be trimmed, should work
- [ ] Set `PROXMOX_BASE_URL='ftp://...'` — should print error and exit
- [ ] Set only `PROXMOX_HOST` (no `PROXMOX_BASE_URL`) — should fall back and work as before
- [ ] Set neither — should print usage error and exit