### PR TITLE
Add agent skills and scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# proxmox-sh
+
+Proxmox VM/LXC management skills and scripts for agent-assisted deploys.
+
+## Setup
+
+Skills should be symlinked into the agent's global skills directory so they
+are discoverable. If the symlinks are missing, suggest creating them.
+
+The three skill directories to link:
+
+```
+skills/proxmox
+skills/proxmox-create-vm
+skills/proxmox-dns
+```
+
+## Structure
+
+```
+skills/
+  proxmox/              Index skill (load first)
+    scripts/            Shell scripts (agent runs these, not the user)
+    references/         On-demand reference files
+  proxmox-create-vm/    VM creation sub-skill
+  proxmox-dns/          DNS management sub-skill
+    references/         Apex domain reference (loaded on demand)
+```
+
+## Conventions
+
+- Scripts output TSV with `# section` headers and `# AGENT:` inline hints
+- Skills target 32k-context mid-tier/on-device agents
+- Agent runs all scripts directly; only escalates to the user on roadblocks
+- Script output is hidden from the user; agent must reformat into response text

--- a/skills/proxmox-create-vm/SKILL.md
+++ b/skills/proxmox-create-vm/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: proxmox-create-vm
+description:
+  Create LXC containers on Proxmox with proxmox-create. Use when provisioning new VMs,
+  choosing sizing, or understanding VMID/IP assignment.
+---
+
+## Creating an LXC Container
+
+### Step 1: Read defaults from the active env
+
+```sh
+grep -E 'PROXMOX_TEMPLATE_DEFAULT|PROXMOX_TARGET_NODE|PROXMOX_ID_PREFIX' \
+    ~/.config/proxmox-sh/current.env
+```
+
+### Step 2: Choose the OS template
+
+```sh
+sh ~/Agents/skills/proxmox/scripts/proxmox-sh-templates
+```
+
+Present the numbered list to the user. Guide the choice:
+
+- **systemd required** (most services) => Ubuntu
+- **OpenRC / minimal** (static sites, simple daemons) => Alpine
+- Prefer: `custom` > `bnna` variant > `standard`
+- The `default` tag marks the env's `PROXMOX_TEMPLATE_DEFAULT`
+
+### Step 3: Run the command
+
+MUST: Always pass `--os` with a full `vztmpl/...` path.
+
+Wrap with `expect` to provide a pty (`proxmox-create` writes to `/dev/tty`):
+
+```sh
+expect -c 'spawn proxmox-create <hostname> \
+    --os <PROXMOX_TEMPLATE_DEFAULT> \
+    --storage <gb> --ram <mb> --vcpus <n>; \
+    expect eof'
+```
+
+Output shows the assigned CTID, IP, and direct-IP domains. Example:
+
+```
+CTID:    1104209
+IP:      10.11.4.209/24
+Direct:  tls-10-11-4-209.<DIRECT_IP_DOMAIN>
+```
+
+**Common errors:**
+
+- **403 on pool** -- the env's `PROXMOX_RESOURCE_POOL` doesn't exist or isn't
+  accessible. Run `proxmox-sh-resources` and pick from the listed pools.
+- **500 on create** -- usually a storage or network config issue. Check that
+  the VNET/bridge and storage pool exist on the target node.
+- **"already exists"** -- the VMID is taken. `proxmox-create` auto-increments,
+  so this is rare. If it happens, retry.
+
+## Container Layout
+
+- `/` (rootfs) -- 8 GB, fixed, from `PROXMOX_FS_POOL`
+- `/mnt/storage` -- `--storage` size, from `PROXMOX_DATA_POOL`
+
+The `--storage` flag sets `/mnt/storage` size, not rootfs.
+
+## Standard Sizing
+
+| Tier | RAM | vCPU | Storage | Use case |
+|------|-----|------|---------|----------|
+| Minimal | 512 MB | 1 | 1 GB | Static sites, simple services |
+| Dev | 2048 MB | 2 | 10 GB | Development instances |
+| Standard | 4096 MB | 2 | 20 GB | Production services |
+| Heavy | 8192 MB | 4 | 50 GB | Databases, build servers |
+
+## VMID and IP Assignment
+
+VMIDs are auto-assigned: `<PROXMOX_ID_PREFIX><3-digit-index>`.
+The index maps to the last IP octet:
+
+```
+Prefix: 1104, Next index: 209
+VMID:   1104209
+IP:     10.11.4.209/24
+GW:     10.11.4.1
+```
+
+## Post-Creation
+
+1. **TLS certificate** -- `proxmox-create` initiates ACME issuance automatically
+2. **DNS** -- Set up friendly domains (see `proxmox-dns` skill)
+3. **SSH access** -- Wait for container init, then confirm:
+
+```sh
+sh ~/Agents/skills/proxmox/scripts/proxmox-sh-ssh-wait <direct-ip-domain> [<friendly-domain>]
+```
+
+Phase 1: SSH on direct-IP with backoff (7s/15s/15s), auto-detects user (`root` standard, `app` bnna).
+Phase 2: If friendly domain given, polls DNS propagation (max 20s).
+On DNS WARN, verify CNAME (subdomain) or A+SRV (apex) records via domainpanel.

--- a/skills/proxmox-dns/SKILL.md
+++ b/skills/proxmox-dns/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: proxmox-dns
+description:
+  DNS record management for Proxmox VMs using domainpanel. Use when mapping domains
+  to VMs, creating direct-IP CNAMEs, setting up A+SRV for apex domains, or listing
+  existing records. Covers domainpanel CLI, record type selection, and TLS router integration.
+---
+
+## Prerequisites
+
+MUST: Run `proxmox-sh-doctor` first (see `proxmox` index skill) to confirm the
+`DIRECT_IP_DOMAIN` value and list running VMs with their IPs.
+
+**DNS tool:** Check if domainpanel is available:
+
+```sh
+test -d ~/Agents/domainpanel && echo "OK" || echo "MISSING"
+```
+
+If available, check `~/Agents/domainpanel/config.tsv` for configured accounts.
+
+If domainpanel is NOT available, ask the user for:
+1. Their DNS host/registrar (e.g. Cloudflare, Name.com, Route53)
+2. An API token for that provider
+
+Then create the DNS records via the provider's API with curl. Most common
+providers accept a simple POST to create CNAME records. The agent should
+look up the provider's API docs and construct the curl call.
+
+## Direct-IP Domain Pattern
+
+Every Proxmox VM IP maps to two DNS-resolvable domains automatically:
+
+```
+IP 10.11.4.209 -> tls-10-11-4-209.<DIRECT_IP_DOMAIN>   (HTTPS proxy to port 3080)
+IP 10.11.4.209 -> tcp-10-11-4-209.<DIRECT_IP_DOMAIN>   (raw TCP proxy to port 443)
+```
+
+- `tls-` prefix: TLS-terminated HTTP, proxied to port 3080 with `X-Forwarded-*` headers
+- `tcp-` prefix: Raw TLS passthrough to port 443
+
+`DIRECT_IP_DOMAIN` comes from the active proxmox-sh env profile (e.g., `<DIRECT_IP_DOMAIN>`).
+
+## Workflow: Map a Domain to a VM
+
+### Step 1: Compute the direct-IP domain
+
+Convert the VM's IP to a direct-IP domain:
+
+```sh
+# IP: 10.11.4.209
+# Direct-IP: tls-10-11-4-209.<DIRECT_IP_DOMAIN>
+```
+
+Formula: replace dots with dashes, prepend `tls-`, append `.<DIRECT_IP_DOMAIN>`.
+
+### Step 2: Create records
+
+Use the dns-add script -- it auto-detects subdomain vs apex:
+
+```sh
+sh ~/Agents/skills/proxmox/scripts/proxmox-sh-dns-add <friendly-domain> <direct-ip-domain>
+sh ~/Agents/skills/proxmox/scripts/proxmox-sh-dns-add app.example.com tls-10-11-4-209.<DIRECT_IP_DOMAIN>
+```
+
+For ccTLDs or other multi-part apex domains (e.g. `example.co.uk`):
+
+```sh
+sh ~/Agents/skills/proxmox/scripts/proxmox-sh-dns-add example.co.uk tls-10-11-4-209.<DIRECT_IP_DOMAIN> --apex
+```
+
+For raw TCP passthrough (port 443), use `tcp-` instead of `tls-`:
+
+```sh
+sh ~/Agents/skills/proxmox/scripts/proxmox-sh-dns-add app.example.com tcp-10-11-4-209.<DIRECT_IP_DOMAIN>
+```
+
+If domainpanel is not available, the script prints the records needed and
+instructs the agent to ask for DNS host + API token.
+
+MUST: Read `./references/apex-domains.md` when the user needs a bare apex domain
+and you need to understand the SRV record format, port rules, or RFC 2782 details.
+
+### Step 4: Verify
+
+```sh
+cd ~/Agents/domainpanel
+
+# List records for the zone
+go run ./cmd/domainpanel/ -records -tsv | grep example.com
+
+# Or check via dig
+dig +short CNAME app.example.com
+dig +short A example.com
+```
+
+## domainpanel CLI Reference
+
+All commands run from `~/Agents/domainpanel/`:
+
+```sh
+# List all DNS records
+go run ./cmd/domainpanel/ -records
+
+# List as TSV (machine-parseable)
+go run ./cmd/domainpanel/ -records -tsv
+
+# Create a record
+go run ./cmd/domainpanel/ -create-host <FQDN> -type <TYPE> -data <VALUE> [-ttl <SECONDS>]
+
+# Create or update a record
+go run ./cmd/domainpanel/ -update-host <FQDN> -type <TYPE> -data <VALUE> [-ttl <SECONDS>]
+
+# Update when multiple records of same type exist
+go run ./cmd/domainpanel/ -update-host <FQDN> -type <TYPE> -data <NEW> -match-data <OLD>
+
+# Delete a record
+go run ./cmd/domainpanel/ -delete-host <FQDN> [-type <TYPE>]
+# -type ALL deletes all record types
+
+# Bulk import from file
+go run ./cmd/domainpanel/ -import records.tsv [-dry-run]
+```
+
+Default TTL: 300 seconds. Default type: A.
+
+## Zone Discovery
+
+domainpanel infers the zone from the FQDN and configured accounts. You do not
+specify zones separately — just use the full hostname:
+
+```sh
+# domainpanel figures out that example.com is the zone
+go run ./cmd/domainpanel/ -create-host app.example.com -type A -data 1.2.3.4
+```
+
+If the zone is not managed by any configured account, the command will error.
+
+## Updating and Deleting Records
+
+```sh
+# Update an existing record (creates if missing)
+go run ./cmd/domainpanel/ -update-host app.example.com -type CNAME \
+    -data tls-10-11-8-50.<DIRECT_IP_DOMAIN>
+
+# When multiple records of the same type exist, use -match-data
+go run ./cmd/domainpanel/ -update-host app.example.com -type A \
+    -data 10.11.8.50 -match-data 10.11.4.209
+
+# Delete
+go run ./cmd/domainpanel/ -delete-host app.example.com -type CNAME
+```
+
+Note: `libdns SetRecords` replaces the entire RRset for `(name, type)`. Use
+`-match-data` for targeted single-record updates.
+
+## DNS Health Check
+
+After creating records, use dnscheck to validate:
+
+```sh
+cd ~/Agents/domainpanel
+
+# Export current records
+go run ./cmd/domainpanel/ -records -tsv > records.tsv
+
+# Run health checks (SPF, DMARC, MX, CAA, dangling CNAMEs)
+go run ./cmd/dnscheck/
+
+# Preview auto-fixes
+go run ./cmd/dnscheck/ -fix --dry-run
+```
+
+## Related Skills
+
+- `proxmox-create-vm` — Create VMs (do this before DNS)
+- `proxmox` — Index skill with doctor script (run first)

--- a/skills/proxmox-dns/references/apex-domains.md
+++ b/skills/proxmox-dns/references/apex-domains.md
@@ -1,0 +1,59 @@
+# Apex Domain DNS (A + SRV)
+
+Apex domains (`example.com`, not `app.example.com`) cannot use CNAME.
+Use A record for the IP plus SRV for TLS Router service routing.
+
+Prefer CNAME for subdomains. Use A+SRV only when an apex domain is required.
+
+## Create Records
+
+```sh
+cd ~/Agents/domainpanel
+
+# A record with the VM's actual IP
+go run ./cmd/domainpanel/ -create-host example.com \
+    -type A \
+    -data 10.11.4.209
+
+# SRV record for HTTP routing via TLS router
+# NOTE: Some DNS providers enforce RFC 2782 which requires the SRV target
+# to be within the zone. The target becomes <DIRECT_IP_DOMAIN>.<APEX_DOMAIN>.
+# The TLS Router knows to strip the apex suffix to interpret the direct-IP domain.
+go run ./cmd/domainpanel/ -create-host _http._tcp.example.com \
+    -type SRV \
+    -data "10 1 3080 tls-10-11-4-209.<DIRECT_IP_DOMAIN>.example.com"
+```
+
+## Rules
+
+- SRV targets must be direct-IP domains the TLS router trusts (`*.<DIRECT_IP_DOMAIN>`).
+- Port MUST be a pre-defined TLS Router port. The TLS Router does not allow
+  arbitrary ports for dynamic configuration -- this is a security measure.
+- The SRV target may need `.<APEX_DOMAIN>` appended depending on DNS provider
+  RFC 2782 enforcement. The TLS Router strips the apex suffix automatically.
+
+## SRV Record Format
+
+SRV data is a single string: `<priority> <weight> <port> <target>`
+
+```sh
+go run ./cmd/domainpanel/ -create-host _http._tcp.example.com \
+    -type SRV \
+    -data "10 1 3080 tls-10-11-4-209.<DIRECT_IP_DOMAIN>.example.com"
+```
+
+## Allowed Services and Ports
+
+Port MUST be one of these pre-defined TLS Router ports:
+
+| Service | Name | Port | Origin | Notes |
+|---------|------|------|--------|-------|
+| HTTP | `_http._tcp` | 3080 | 80+3000 | Caddy proxy (most common) |
+| Raw TLS | `_http._tcp` | 443 | passthrough | Direct TLS passthrough |
+| H2 | `_h2._tcp` | 443 | passthrough | HTTP/2 direct |
+| SSH | `_ssh._tcp` | 22 | standard | SSH access |
+| PostgreSQL | `_postgresql._tcp` | 15432 | 5432+10000 | Database |
+| MQTT | `_mqtt._tcp` | 11883 | 1883+10000 | Message broker |
+
+Port offset pattern: internal port = external port + 10000 (ensuring manual
+configuration before exposure). Exceptions: HTTP (3080) and SSH (22).

--- a/skills/proxmox/SKILL.md
+++ b/skills/proxmox/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: proxmox
+description:
+  Proxmox VM/LXC management index skill. Use when creating VMs, listing containers,
+  managing Proxmox environments, or any Proxmox-related task. Load this first - it
+  runs the doctor script and points to focused sub-skills.
+---
+
+**Self-improving process.** As you work through these steps, note anything
+confusing, missing, or wrong -- unclear script output, missing agent hints,
+wrong defaults, steps that should be automated. Collect these as you go.
+
+## End-to-End Workflow
+
+The full deploy flow runs in order. Each step produces structured output with
+`# AGENT:` hints. Run each script, read the hints, and act on them.
+
+1. **Doctor** -- validate environment, check connectivity
+2. **Scan** -- list available pools, VMs, storages, SDN
+3. **Confirm profile** -- pick or confirm the Proxmox account
+4. **SSH pre-flight** -- ensure SSH config has the wildcard entry
+5. **Choose template** -- pick the OS for the new VM
+6. **Create VM** -- provision the LXC container (see `proxmox-create-vm` skill)
+7. **DNS** -- map a friendly domain to the VM (see `proxmox-dns` skill)
+8. **SSH verify** -- confirm SSH access, check DNS propagation
+
+Steps 1-4 are startup/pre-flight. Steps 5-8 are the create flow.
+Not every task needs all steps -- listing VMs only needs 1-3.
+
+## Startup (run in order)
+
+### 1. Doctor
+
+```sh
+sh ~/Agents/skills/proxmox/scripts/proxmox-sh-doctor
+```
+
+On success (exit 0): proceed silently. On warnings (exit 2): mention relevant
+WARNs but continue. On failure (exit 1): the user needs to provide 4 values:
+
+1. `PROXMOX_HOST` -- API endpoint (from their admin)
+2. `PROXMOX_TOKEN_ID` -- token identity (from their admin)
+3. `PROXMOX_TOKEN_SECRET` -- token secret (from their admin)
+4. `DIRECT_IP_DOMAIN` -- direct-IP domain suffix (from their admin)
+
+Everything else can be discovered. Create a minimal env file with these 4,
+then run env-defaults to fill in the rest:
+
+```sh
+sh ~/Agents/skills/proxmox/scripts/proxmox-sh-env-defaults --env <file>
+```
+
+It queries the API and prints `SUGGEST` lines for every missing variable
+(node, pool, vnet, template storage, default template, ID prefix).
+See `~/.local/opt/proxmox-sh/example.proxmox-sh.env` for the full field list.
+
+### 2. Scan all tokens
+
+```sh
+sh ~/Agents/skills/proxmox/scripts/proxmox-sh-resources-all
+```
+
+Individual profile failures are fine. Output shows each token's pools,
+storages, VMs, SDN zones, node grants. Don't dump the full output to the user;
+summarize: N VMs running, pools available, any warnings.
+
+For a single profile: `sh .../proxmox-sh-resources [--detail] [--env <file>]`
+`--detail` adds node CPU/memory, vnet details, pool member counts, templates.
+
+### 3. Confirm account
+
+```sh
+sh ~/Agents/skills/proxmox/scripts/proxmox-sh-profiles
+```
+
+Present as a numbered pick list. Highlight which is `[current]`.
+If only one profile exists, confirm it rather than making the user choose.
+Switch with `env-switch proxmox-sh <profile-name>` if needed.
+
+## Rules
+
+- **Respect token permissions.** Advise when permissions are lacking. Investigate
+  before concluding (pool propagation, node vs VM scope). Never bypass.
+  MUST read `references/minimum-permissions.csv` on 403 errors, new token
+  setup, or when advising what a token can/cannot do.
+- **Agent runs all scripts.** Only escalate to the user on actual roadblocks.
+- **MUST pass `--os vztmpl/...`** to `proxmox-create` (required in current version).
+- **MUST get explicit permission** before touching `~/.ssh/config`.
+- **Validate pool before create.** The env's `PROXMOX_RESOURCE_POOL` may not exist.
+  Run `proxmox-sh-resources` and pick from the listed pools.
+
+## VM Pre-flight
+
+**OS selection:** systemd => Ubuntu, OpenRC/minimal => Alpine.
+Flavor preference: user's own template > `bnna` variant > default.
+
+**SSH config:** Check before creating a VM:
+
+```sh
+sh ~/Agents/skills/proxmox/scripts/proxmox-sh-ssh-check
+```
+
+If missing, it prints the entry to add. MUST get explicit permission before
+touching `~/.ssh/config`. Ask if they also want a friendly CNAME
+(e.g. `feat-foo.example.com` -> `tls-10-11-xx-yy.<DIRECT_IP_DOMAIN>`).
+If CNAME, also add a host-specific SSH entry:
+
+```
+Host feat-foo.example.com
+    Hostname tls-10-11-xx-yy.<DIRECT_IP_DOMAIN>
+    ProxyCommand sclient --alpn ssh %h
+```
+
+**proxmox-create** writes to `/dev/tty` which fails without a terminal.
+Wrap with expect: `expect -c 'spawn proxmox-create ...; expect eof'`
+See `proxmox-create-vm` sub-skill for flags, sizing, VMID/IP scheme.
+
+## Post-Create
+
+After `proxmox-create` succeeds, three things happen in order:
+
+### 1. DNS setup
+
+Ask the user if they want a friendly domain. Present:
+- The `DIRECT_IP_DOMAIN` from the env (already working, no DNS needed)
+- Managed DNS zones (from `domainpanel -records -tsv | cut -f1 | sort -u`)
+- A suggested name like `<slug>-<octet>.<zone>` (e.g. `dev-209.example.com`)
+
+Then run the dns-add script (see `proxmox-dns` sub-skill for full details):
+
+```sh
+sh ~/Agents/skills/proxmox/scripts/proxmox-sh-dns-add <friendly-domain> <direct-ip-domain>
+```
+
+The script auto-detects subdomain vs apex, checks domainpanel availability,
+and prints `# AGENT:` hints for every decision point. If domainpanel is missing
+or the zone isn't managed, it tells you to ask the user for their DNS provider
+and API token.
+
+### 2. SSH readiness
+
+Container init continues after Proxmox reports the task as complete. The
+ssh-wait script handles the backoff timing automatically:
+
+```sh
+sh ~/Agents/skills/proxmox/scripts/proxmox-sh-ssh-wait <direct-ip-domain> [<friendly-domain>]
+```
+
+Phase 1: SSH on direct-IP with backoff (7s/15s/15s), auto-detects user
+(`root` for standard templates, `app` for bnna/custom templates).
+Phase 2: If friendly domain given, polls DNS propagation via SSH (max 20s).
+
+### 3. Summary
+
+After ssh-wait succeeds, present the user a summary:
+- CTID, OS, SSH user
+- Direct-IP domain (always works)
+- Friendly domain (if set)
+- SSH command: `ssh <user>@<domain>`
+
+On DNS WARN: verify the record was created correctly using domainpanel.
+Subdomain: check CNAME. Apex: check A + SRV records.
+
+## Quick Reference
+
+**Direct-IP domains:** IP `10.11.4.209` becomes:
+
+- `tls-10-11-4-209.<DIRECT_IP_DOMAIN>` -- HTTPS proxy to port 3080
+- `tcp-10-11-4-209.<DIRECT_IP_DOMAIN>` -- raw TCP proxy to port 443
+
+**TLS Router (ALPN-based forwarding):** The TLS router inspects ALPN to route
+traffic. Internal ports are typically external port + 10000, ensuring services
+require manual configuration before exposure:
+
+| Protocol | ALPN | Container port | Why offset |
+|----------|------|---------------|------------|
+| HTTPS | `http/1.1`, `h2` | 3080 | 80 + 3000 |
+| SSH | `ssh` | 22 | standard |
+| PostgreSQL | `postgresql` | 15432 | 5432 + 10000 |
+| MySQL | `mysql` | 13306 | 3306 + 10000 |
+| MQTT | `mqtt` | 11883 | 1883 + 10000 |
+| Raw TLS | (none) | 443 | passthrough |
+
+**DNS for friendly domains:**
+
+Subdomain (most common) -- CNAME to `tls-` direct-IP domain:
+
+```
+CNAME  app.example.com  tls-10-11-4-209.<DIRECT_IP_DOMAIN>
+```
+
+Apex domain (SHOULD, more complex -- only when apex is required):
+
+```
+A      example.com            10.11.4.209
+SRV    _http._tcp.example.com 10 1 3080 tls-10-11-4-209.<DIRECT_IP_DOMAIN>.example.com
+```
+
+SRV target appends `.<APEX_DOMAIN>` due to RFC 2782 enforcement by some DNS
+providers. The TLS Router strips the apex suffix. Port MUST be a pre-defined
+TLS Router port (see `proxmox-dns` skill for full list).
+
+**VMID scheme:** `<PREFIX><3-digit-index>` -- prefix `1104` + index `209` =
+VMID `1104209`, IP `10.11.4.209`.
+
+**Pool conventions:** `*-active`, `*-dev`, `*-prod`, `*-offline`.
+
+## Sub-skills
+
+| Skill | When |
+|-------|------|
+| `proxmox-create-vm` | Creating LXC containers |
+| `proxmox-dns` | DNS record management (domainpanel) |
+
+## proxmox-sh Tools
+
+Installed at `~/.local/opt/proxmox-sh/`, commands in `bin/`:
+
+| Command | Purpose |
+|---------|---------|
+| `proxmox-create` | Create LXC containers |
+| `env-switch` | Switch active environment profile |
+| `proxmox-sh-init` | Initialize config dirs and example env |
+| `proxmox-sh-update` | Git pull latest proxmox-sh |
+| `caddy-add` | Add reverse proxy routes via Caddy API |
+
+## After Completion
+
+Review your notes from the process. If anything was confusing, missing, or
+wrong -- suggest updates to the scripts or skill files so the next run is
+smoother.

--- a/skills/proxmox/references/minimum-permissions.csv
+++ b/skills/proxmox/references/minimum-permissions.csv
@@ -1,0 +1,44 @@
+operation,privilege,acl_path,builtin_role,scopeable,gap_notes
+# Audit — see what you have
+List own pools,Pool.Audit,/pool/{pool},PVEPoolAdmin,yes,
+Get pool members,Pool.Audit,/pool/{pool},PVEPoolAdmin,yes,
+List VMs/CTs in pool,VM.Audit,/pool/{pool},PVEVMAdmin,yes,inherits to pool members
+Get VM/CT status and config,VM.Audit,/vms/{vmid},PVEVMAdmin,yes,
+List storage content (templates),Datastore.Audit,/storage/{storage},PVEDatastoreUser,yes,
+Query own token permissions,(any),/access/permissions,,yes,always works
+List cluster resources,Sys.Audit,/,PVEAuditor,no,returns ALL cluster VMs; no per-pool filter; use pool endpoint instead
+Node summary (cpu/mem/uptime),Sys.Audit,/nodes/{node},PVEAuditor,no,requires node-level grant; tenant cannot see host utilization without it
+Read VM metrics / RRD,VM.Audit,/vms/{vmid},PVEVMAdmin,yes,per-VM only; no aggregate dashboard without Sys.Audit on node
+# VM / CT Lifecycle
+Create CT or VM,VM.Allocate + VM.Config.*,/pool/{pool},PVEVMAdmin,yes,also needs Datastore.AllocateSpace on storage
+Allocate disk for new VM,Datastore.AllocateSpace,/storage/{storage},PVEDatastoreAdmin,yes,
+Add new VM to pool,Pool.Allocate,/pool/{pool},PVEPoolAdmin,yes,
+Attach NIC to vnet,SDN.Use,/sdn/zones/{zone},PVESDNUser,yes,zone grant covers all vnets in it
+Start / stop / shutdown / reboot,VM.PowerMgmt,/vms/{vmid},PVEVMAdmin,yes,
+Update VM/CT config (cpu/ram/disk/net),VM.Config.*,/vms/{vmid},PVEVMAdmin,yes,
+Console access (noVNC / xterm),VM.Console,/vms/{vmid},PVEVMAdmin,yes,
+Destroy (delete) VM/CT,VM.Allocate,/vms/{vmid},PVEVMAdmin,yes,
+Clone from shared template,VM.Clone + VM.Allocate,/vms/{template} + /pool/{pool},PVEVMAdmin,yes,needs PVETemplateUser on template storage
+Snapshot,VM.Snapshot,/vms/{vmid},PVEVMAdmin,yes,
+Rollback snapshot,VM.Snapshot.Rollback,/vms/{vmid},PVEVMAdmin,yes,
+# Backup and Restore
+Backup VM/CT,VM.Backup,/vms/{vmid},PVEVMAdmin,yes,also needs Datastore.AllocateSpace on backup storage
+List backups,Datastore.Audit,/storage/{pbs},PVEDatastoreUser,yes,
+Restore from backup,VM.Allocate + Datastore.AllocateSpace,/pool/{pool} + /storage/{pbs},PVEVMAdmin + PVEDatastoreUser,yes,
+# Pool Housekeeping
+Move VM between own pools,Pool.Allocate,/pool/{src} + /pool/{dst},PVEPoolAdmin,yes,e.g. active <-> offline
+Update pool comment,Pool.Allocate,/pool/{pool},PVEPoolAdmin,yes,
+# Migration
+Migrate CT/VM between nodes,VM.Migrate,/vms/{vmid},PVEVMAdmin,partial,works if token has grants on both nodes; cross-node storage may need Sys.Audit
+# Guest Agent
+Query guest agent (IP/hostname/OS),VM.Audit,/vms/{vmid},PVEVMAdmin,yes,qemu-guest-agent must be running
+Run guest agent commands,VM.GuestAgent.*,/vms/{vmid},PVEVMAdmin,yes,file read/write/exec inside guest
+# Things a tenant reasonably wants but CANNOT scope
+HA group management,Sys.Console,/,PVESysAdmin,no,requires root-level grant; no per-pool HA; must ask cluster admin
+Node CPU/memory summary,Sys.Audit,/nodes/{node},PVEAuditor,no,tenant cannot see if host is overcommitted; only per-VM metrics available
+ZFS dataset resize / quota,Sys.Modify,/nodes/{node},,no,no API; requires shell access on PVE node to run zfs set
+Download OS templates (pveam),Datastore.AllocateSpace,/storage/{storage} + /nodes/{node},PVEDatastoreAdmin,partial,tenant can download to own storage; pveam update (catalog refresh) requires Sys.Modify on node
+Scheduled backup jobs (vzdump.cron),Sys.Audit,/,PVEAuditor,no,GET /cluster/backup lists ALL cluster jobs; no per-pool filter
+Firewall rules (datacenter-level),Sys.Modify,/,,no,tenant can set VM-level firewall but not cluster/host rules
+Create additional pools,Pool.Allocate,/pool (root),PVEPoolAdmin,no,pool creation is a root-path operation; tenant gets pre-provisioned pools
+Create SDN zone or vnet,SDN.Allocate,/sdn,,no,cluster-wide config; tenant uses pre-provisioned zone

--- a/skills/proxmox/scripts/proxmox-sh-dns-add
+++ b/skills/proxmox/scripts/proxmox-sh-dns-add
@@ -1,0 +1,235 @@
+#!/bin/sh
+set -e
+set -u
+
+# proxmox-sh-dns-add: create DNS records for a Proxmox VM friendly domain
+#
+# Auto-detects subdomain vs apex domain and creates the right records:
+#   - Subdomain: CNAME -> tls-<ip>.<DIRECT_IP_DOMAIN>
+#   - Apex: A record + SRV record (with RFC 2782 target format)
+#
+# Usage:
+#   proxmox-sh-dns-add <friendly-domain> <direct-ip-domain>
+#   proxmox-sh-dns-add dev-209.example.com tls-10-11-4-209.vms.example.com
+#   proxmox-sh-dns-add example.com tls-10-11-4-209.vms.example.com --apex
+#
+# Options:
+#   --apex    Force apex domain treatment (for ccTLDs like example.co.uk)
+#
+# Exit codes:
+#   0 - records created
+#   1 - missing args or domainpanel not available
+#
+# AGENT: Run this after proxmox-create and DNS domain selection.
+#   On exit 1 with "domainpanel not available", ask the user for their
+#   DNS host and API token, then create the records via curl.
+#   On exit 1 with "zone not managed", the user's domain isn't configured
+#   in domainpanel -- ask which DNS provider manages it.
+#   On success, pass the friendly domain to proxmox-sh-ssh-wait as arg 2.
+
+g_apex=false
+
+fn_usage() {
+	echo "Usage: proxmox-sh-dns-add <friendly-domain> <direct-ip-domain> [--apex]"
+	echo ""
+	echo "Create DNS records (CNAME for subdomains, A+SRV for apex)."
+	echo "  --apex    Force apex domain treatment"
+}
+
+fn_is_apex() {
+	a_domain="${1}"
+
+	if "${g_apex}"; then
+		return 0
+	fi
+
+	# Count dots: example.com = 1 dot = apex, app.example.com = 2+ = subdomain
+	b_dots="$(echo "${a_domain}" | tr -cd '.' | wc -c | tr -d ' ')"
+	if test "${b_dots}" -le 1; then
+		return 0
+	fi
+
+	return 1
+}
+
+fn_extract_ip() {
+	# tls-10-11-4-209.vms.example.com -> 10.11.4.209
+	a_direct="${1}"
+	echo "${a_direct}" | sed 's;^[a-z]*-;;' | sed 's;\..*;;' | tr '-' '.'
+}
+
+fn_print_context() {
+	a_friendly="${1}"
+	a_direct="${2}"
+
+	echo "# dns-add"
+	printf 'friendly\t%s\n' "${a_friendly}"
+	printf 'direct\t%s\n' "${a_direct}"
+
+	b_ip="$(fn_extract_ip "${a_direct}")"
+	printf 'ip\t%s\n' "${b_ip}"
+
+	# Detection
+	if fn_is_apex "${a_friendly}"; then
+		printf 'detect\tapex\n'
+		echo "# AGENT: apex domain detected. Will create A + SRV records."
+		echo "# AGENT: if this is wrong (e.g. subdomain of a ccTLD), omit --apex and retry."
+	else
+		printf 'detect\tsubdomain\n'
+		echo "# AGENT: subdomain detected. Will create a CNAME record."
+		echo "# AGENT: if this is actually an apex domain (e.g. example.co.uk), rerun with --apex."
+	fi
+
+	# Domainpanel status
+	if test -d ~/Agents/domainpanel; then
+		printf 'domainpanel\tavailable\n'
+
+		# List managed zones so agent knows which domains it can create records for
+		b_zones="$(cd ~/Agents/domainpanel && go run ./cmd/domainpanel/ -records -tsv 2>/dev/null \
+			| cut -f1 | sort -u | grep -v '^zone$')" || true
+		if test -n "${b_zones}"; then
+			printf 'zones\t%s\n' "$(echo "${b_zones}" | tr '\n' ',' | sed 's/,$//')"
+
+			# Check if friendly domain matches a managed zone
+			b_matched=false
+			for b_zone in ${b_zones}; do
+				case "${a_friendly}" in
+				"${b_zone}" | *".${b_zone}")
+					printf 'zone_match\t%s\n' "${b_zone}"
+					echo "# AGENT: domain is in managed zone '${b_zone}'. Records can be created automatically."
+					b_matched=true
+					break
+					;;
+				esac
+			done
+			if ! "${b_matched}"; then
+				printf 'zone_match\tnone\n'
+				echo "# AGENT: domain is NOT in any managed zone. domainpanel cannot create these records."
+				echo "# AGENT: ask the user which DNS provider manages this domain and for an API token."
+				echo "# AGENT: alternatively, the user can pick a domain from the managed zones above."
+			fi
+		fi
+	else
+		printf 'domainpanel\tnot available\n'
+		echo "# AGENT: domainpanel is not installed. Ask the user for their DNS"
+		echo "# AGENT: host/registrar and an API token, then create records via curl."
+	fi
+
+	echo ""
+}
+
+fn_print_manual() {
+	a_friendly="${1}"
+	a_direct="${2}"
+
+	echo "# manual-dns"
+	echo "# AGENT: create these records using the DNS provider's API (curl)."
+	echo "# AGENT: you will need the provider name and an API token from the user."
+	if fn_is_apex "${a_friendly}"; then
+		b_ip="$(fn_extract_ip "${a_direct}")"
+		echo "# Two records needed for apex domain:"
+		printf 'A\t%s\t%s\n' "${a_friendly}" "${b_ip}"
+		printf 'SRV\t_http._tcp.%s\t10 1 3080 %s.%s\n' "${a_friendly}" "${a_direct}" "${a_friendly}"
+		echo "# AGENT: SRV target appends the apex domain for RFC 2782 compliance."
+		echo "# AGENT: port 3080 is required (TLS Router pre-defined port for HTTP)."
+	else
+		echo "# One record needed for subdomain:"
+		printf 'CNAME\t%s\t%s\n' "${a_friendly}" "${a_direct}"
+	fi
+}
+
+main() {
+	b_friendly=""
+	b_direct=""
+
+	while test -n "${1:-}"; do
+		case "${1}" in
+		--apex)
+			g_apex=true
+			;;
+		--help | -help | help)
+			fn_usage
+			return 0
+			;;
+		-*)
+			echo "Unknown flag: ${1}" >&2
+			fn_usage >&2
+			return 1
+			;;
+		*)
+			if test -z "${b_friendly}"; then
+				b_friendly="${1}"
+			elif test -z "${b_direct}"; then
+				b_direct="${1}"
+			else
+				echo "ERROR: unexpected argument: ${1}" >&2
+				fn_usage >&2
+				return 1
+			fi
+			;;
+		esac
+		shift
+	done
+
+	if test -z "${b_friendly}" || test -z "${b_direct}"; then
+		echo "ERROR: friendly-domain and direct-ip-domain required" >&2
+		echo ""
+		fn_usage >&2
+		return 1
+	fi
+
+	# Print context for the agent
+	fn_print_context "${b_friendly}" "${b_direct}"
+
+	# Check domainpanel (context already printed above with agent hints)
+	if ! test -d ~/Agents/domainpanel; then
+		fn_print_manual "${b_friendly}" "${b_direct}"
+		return 1
+	fi
+
+	# Create records
+	if fn_is_apex "${b_friendly}"; then
+		b_ip="$(fn_extract_ip "${b_direct}")"
+
+		# A record
+		echo "# creating A record..."
+		cd ~/Agents/domainpanel
+		if ! go run ./cmd/domainpanel/ -create-host "${b_friendly}" \
+			-type A \
+			-data "${b_ip}" 2>&1; then
+			echo "ERROR: failed to create A record" >&2
+			fn_print_manual "${b_friendly}" "${b_direct}"
+			return 1
+		fi
+
+		# SRV record (target includes apex suffix for RFC 2782 compliance)
+		b_srv_target="${b_direct}.${b_friendly}"
+		echo "# creating SRV record..."
+		if ! go run ./cmd/domainpanel/ -create-host "_http._tcp.${b_friendly}" \
+			-type SRV \
+			-data "10 1 3080 ${b_srv_target}" 2>&1; then
+			echo "ERROR: failed to create SRV record" >&2
+			fn_print_manual "${b_friendly}" "${b_direct}"
+			return 1
+		fi
+
+		printf 'created\tA\t%s\t%s\n' "${b_friendly}" "${b_ip}"
+		printf 'created\tSRV\t_http._tcp.%s\t10 1 3080 %s\n' "${b_friendly}" "${b_srv_target}"
+	else
+		echo "# creating CNAME record..."
+		cd ~/Agents/domainpanel
+		if ! go run ./cmd/domainpanel/ -create-host "${b_friendly}" \
+			-type CNAME \
+			-data "${b_direct}" 2>&1; then
+			echo "ERROR: failed to create CNAME record" >&2
+			fn_print_manual "${b_friendly}" "${b_direct}"
+			return 1
+		fi
+
+		printf 'created\tCNAME\t%s\t%s\n' "${b_friendly}" "${b_direct}"
+	fi
+
+	echo "# OK"
+}
+
+main "$@"

--- a/skills/proxmox/scripts/proxmox-sh-doctor
+++ b/skills/proxmox/scripts/proxmox-sh-doctor
@@ -1,0 +1,338 @@
+#!/bin/sh
+set -e
+set -u
+
+# proxmox-sh-doctor: validate proxmox-sh environment for agent use
+#
+# Output format: structured sections with key=value and TSV for tables.
+# Errors and warnings prefixed with ERROR: and WARN: for easy grep.
+# Colored pass/fail summary at the end for human readability.
+#
+# Exit codes:
+#   0 - all checks passed
+#   1 - fatal: missing dependency or broken env
+#   2 - warning: non-fatal issue
+#
+# AGENT: On success (exit 0), proceed to the next startup step silently.
+#   On warnings (exit 2), proceed but mention any WARNs that affect the task.
+#   On failure (exit 1), tell the user which 4 values are needed:
+#     PROXMOX_HOST, PROXMOX_TOKEN_ID, PROXMOX_TOKEN_SECRET, DIRECT_IP_DOMAIN
+#   Offer to create an env file. Don't dump raw error output.
+#   sclient and ssh-pubkey are WARNs, not blockers -- SSH will still work
+#   without them for most setups but TLS-tunneled SSH won't.
+
+g_exit_code=0
+g_ok_count=0
+g_warn_count=0
+g_err_count=0
+
+fn_ok() {
+	g_ok_count=$((g_ok_count + 1))
+	printf 'OK: %s\n' "$1"
+}
+
+fn_warn() {
+	g_warn_count=$((g_warn_count + 1))
+	if test "${g_exit_code}" -lt 2; then
+		g_exit_code=2
+	fi
+	printf 'WARN: %s\n' "$1" >&2
+}
+
+fn_err() {
+	g_err_count=$((g_err_count + 1))
+	g_exit_code=1
+	printf 'ERROR: %s\n' "$1" >&2
+}
+
+# ----------------------------------------
+# Dependencies
+# ----------------------------------------
+fn_check_deps() {
+	echo ""
+	echo "# deps"
+
+	for b_cmd in webi go jq curl sclient ssh-pubkey; do
+		if command -v "${b_cmd}" >/dev/null 2>&1; then
+			b_ver=""
+			case "${b_cmd}" in
+			go) b_ver="$(go version | cut -d' ' -f3)" ;;
+			esac
+			if test -n "${b_ver}"; then
+				printf '%s\t%s\n' "${b_cmd}" "${b_ver}"
+			else
+				printf '%s\tok\n' "${b_cmd}"
+			fi
+		else
+			case "${b_cmd}" in
+			sclient | ssh-pubkey) fn_warn "${b_cmd} not installed (webi ${b_cmd})" ;;
+			webi) fn_warn "${b_cmd} not installed (curl https://webi.sh | sh)" ;;
+			*) fn_err "${b_cmd} not installed (webi ${b_cmd})" ;;
+			esac
+		fi
+	done
+}
+
+# ----------------------------------------
+# proxmox-sh installation
+# ----------------------------------------
+fn_check_install() {
+	echo ""
+	echo "# install"
+
+	if ! test -d ~/.local/opt/proxmox-sh/; then
+		fn_err "proxmox-sh not installed at ~/.local/opt/proxmox-sh/"
+		echo "fix: git clone https://github.com/therootcompany/proxmox-sh.git ~/.local/opt/proxmox-sh"
+		return
+	fi
+	fn_ok "proxmox-sh installed"
+
+	for b_cmd in proxmox-create env-switch; do
+		if command -v "${b_cmd}" >/dev/null 2>&1; then
+			printf '%s\tin-path\n' "${b_cmd}"
+		else
+			fn_warn "${b_cmd} not in PATH (pathman add ~/.local/opt/proxmox-sh/bin)"
+		fi
+	done
+
+	# shellcheck disable=SC2088
+	if test -d ~/.config/proxmox-sh/; then
+		printf 'config-dir\t~/.config/proxmox-sh/\n'
+	else
+		fn_warn "~/.config/proxmox-sh/ missing (run proxmox-sh-init)"
+	fi
+}
+
+# ----------------------------------------
+# Environment files
+# ----------------------------------------
+fn_check_env() {
+	echo ""
+	echo "# env"
+
+	if ! test -d ~/.config/proxmox-sh/; then
+		# shellcheck disable=SC2088
+		fn_err "~/.config/proxmox-sh/ missing"
+		return
+	fi
+
+	# List profiles
+	echo ""
+	echo "# profiles"
+	b_profile_count=0
+	for b_env in ~/.config/proxmox-sh/*.env; do
+		b_name="$(basename "${b_env}")"
+		if test "${b_name}" = "*.env"; then
+			fn_warn "no .env files found"
+			return
+		fi
+		case "${b_name}" in
+		current.env | example.env) continue ;;
+		esac
+		b_profile_count=$((b_profile_count + 1))
+		echo "${b_name}"
+	done
+
+	if test "${b_profile_count}" -eq 0; then
+		fn_warn "no profiles found"
+		return
+	fi
+
+	# Check current.env
+	if ! test -e ~/.config/proxmox-sh/current.env; then
+		fn_warn "no current.env symlink (run: env-switch proxmox-sh <profile>)"
+		return
+	fi
+	if ! test -L ~/.config/proxmox-sh/current.env; then
+		fn_warn "current.env is a file, not a symlink"
+		return
+	fi
+
+	# shellcheck disable=SC2012
+	b_current_target="$(ls -l ~/.config/proxmox-sh/current.env | sed 's;.*/;;')"
+
+	echo ""
+	echo "# current-env"
+	printf 'profile\t%s\n' "${b_current_target}"
+
+	# Source and dump config
+	# shellcheck disable=SC1090
+	(
+		. ~/.config/proxmox-sh/current.env || true
+
+		printf 'PROXMOX_HOST\t%s\n' "${PROXMOX_HOST:-}"
+		printf 'PROXMOX_TARGET_NODE\t%s\n' "${PROXMOX_TARGET_NODE:-}"
+		printf 'PROXMOX_ID_PREFIX\t%s\n' "${PROXMOX_ID_PREFIX:-}"
+		printf 'PROXMOX_RESOURCE_POOL\t%s\n' "${PROXMOX_RESOURCE_POOL:-}"
+		if test -n "${PROXMOX_VNET:-}"; then
+			printf 'PROXMOX_VNET\t%s\n' "${PROXMOX_VNET}"
+		elif test -n "${PROXMOX_BRIDGE:-}"; then
+			printf 'PROXMOX_BRIDGE\t%s\n' "${PROXMOX_BRIDGE}"
+		fi
+		printf 'PROXMOX_SEARCH_DOMAIN\t%s\n' "${PROXMOX_SEARCH_DOMAIN:-}"
+		printf 'DIRECT_IP_DOMAIN\t%s\n' "${DIRECT_IP_DOMAIN:-}"
+		printf 'PROXMOX_TEMPLATE_DEFAULT\t%s\n' "${PROXMOX_TEMPLATE_DEFAULT:-}"
+		printf 'PROXMOX_TEMPLATE_STORAGE\t%s\n' "${PROXMOX_TEMPLATE_STORAGE:-}"
+
+		# Validate required
+		for b_var in PROXMOX_HOST PROXMOX_TOKEN_ID PROXMOX_TOKEN_SECRET; do
+			# shellcheck disable=SC2154
+			eval "b_val=\"\${${b_var}:-}\""
+			if test -z "${b_val}"; then
+				echo "ERROR: ${b_var} not set" >&2
+			fi
+		done
+		if test -n "${PROXMOX_TOKEN_ID:-}" && test -n "${PROXMOX_TOKEN_SECRET:-}"; then
+			echo "OK: credentials set"
+		fi
+
+		# Direct-IP domain
+		if test -z "${DIRECT_IP_DOMAIN:-}"; then
+			echo "ERROR: DIRECT_IP_DOMAIN not set" >&2
+		else
+			echo "OK: DIRECT_IP_DOMAIN=${DIRECT_IP_DOMAIN}"
+		fi
+	)
+}
+
+# ----------------------------------------
+# API connectivity
+# ----------------------------------------
+fn_check_api() {
+	echo ""
+	echo "# api"
+
+	if ! test -e ~/.config/proxmox-sh/current.env; then
+		fn_warn "skipping - no current.env"
+		return
+	fi
+
+	# shellcheck disable=SC1090
+	. ~/.config/proxmox-sh/current.env || true
+
+	if test -z "${PROXMOX_HOST:-}" ||
+		test -z "${PROXMOX_TOKEN_ID:-}" ||
+		test -z "${PROXMOX_TOKEN_SECRET:-}"; then
+		fn_warn "skipping - missing credentials"
+		return
+	fi
+
+	b_auth="Authorization: PVEAPIToken=${PROXMOX_TOKEN_ID}=${PROXMOX_TOKEN_SECRET}"
+	b_base_url="https://${PROXMOX_HOST}/api2/json"
+	b_curl="curl --max-time 10 --fail-with-body -sSL"
+
+	if ! b_version="$(${b_curl} -H "${b_auth}" "${b_base_url}/version" 2>&1)"; then
+		fn_err "cannot reach ${PROXMOX_HOST}"
+		echo "${b_version}" >&2
+		return
+	fi
+
+	b_pve_version="$(echo "${b_version}" | jq -r '.data.version // "unknown"')"
+	printf 'pve_version\t%s\n' "${b_pve_version}"
+	fn_ok "API reachable"
+
+	# Permissions
+	fn_check_permissions "${b_curl}" "${b_auth}" "${b_base_url}"
+}
+
+# ----------------------------------------
+# Token permissions
+# ----------------------------------------
+fn_check_permissions() {
+	b_curl="${1}"
+	b_auth="${2}"
+	b_base_url="${3}"
+
+	echo ""
+	echo "# permissions"
+
+	if ! b_perms="$(${b_curl} -H "${b_auth}" "${b_base_url}/access/permissions" 2>&1)"; then
+		fn_warn "cannot query permissions"
+		return
+	fi
+
+	# TSV: path \t perm1,perm2,...
+	echo "${b_perms}" | jq -r '
+		.data | to_entries[]
+		| select(.value | to_entries | map(select(.value == 1)) | length > 0)
+		| [.key, ([.value | to_entries[] | select(.value == 1) | .key] | sort | join(","))]
+		| @tsv
+	' | sort
+
+	# Summary checks
+	b_granted="$(echo "${b_perms}" | jq '[.data | to_entries[] | select(.value | to_entries | map(select(.value == 1)) | length > 0)] | length')"
+	printf 'granted_paths\t%s\n' "${b_granted}"
+
+	echo ""
+	echo "# permission-checks"
+	# Check key privileges exist somewhere
+	for b_check in Pool.Allocate VM.Allocate Datastore.AllocateSpace SDN.Use; do
+		b_has="$(echo "${b_perms}" | jq --arg p "${b_check}" '[.data | to_entries[] | select(.value[$p] == 1)] | length')"
+		if test "${b_has}" -gt 0; then
+			fn_ok "${b_check} granted (${b_has} paths)"
+		else
+			fn_warn "${b_check} not granted"
+		fi
+	done
+}
+
+# ----------------------------------------
+# Summary (colored for humans)
+# ----------------------------------------
+fn_summary() {
+	echo ""
+
+	b_green=""
+	b_yellow=""
+	b_red=""
+	b_reset=""
+	# Only colorize if stderr is a terminal
+	if test -t 2; then
+		b_green='\033[32m'
+		b_yellow='\033[33m'
+		b_red='\033[31m'
+		b_reset='\033[0m'
+	fi
+
+	if test "${g_exit_code}" -eq 0; then
+		printf "${b_green}PASS${b_reset}  %s ok, %s warnings, %s errors\n" "${g_ok_count}" "${g_warn_count}" "${g_err_count}" >&2
+	elif test "${g_exit_code}" -eq 2; then
+		printf "${b_yellow}WARN${b_reset}  %s ok, %s warnings, %s errors\n" "${g_ok_count}" "${g_warn_count}" "${g_err_count}" >&2
+	else
+		printf "${b_red}FAIL${b_reset}  %s ok, %s warnings, %s errors\n" "${g_ok_count}" "${g_warn_count}" "${g_err_count}" >&2
+	fi
+}
+
+fn_usage() {
+	echo "Usage: proxmox-sh-doctor"
+	echo ""
+	echo "Validates proxmox-sh environment: deps, install, env files, API, permissions."
+	echo "Exit codes: 0=pass, 1=error, 2=warning"
+}
+
+main() {
+	case "${1:-}" in
+	--help | -help | help)
+		fn_usage
+		return 0
+		;;
+	-* | ?*)
+		echo "Unknown argument: ${1}" >&2
+		echo ""
+		fn_usage >&2
+		return 1
+		;;
+	esac
+
+	echo "# proxmox-sh-doctor"
+
+	fn_check_deps
+	fn_check_install
+	fn_check_env
+	fn_check_api
+	fn_summary
+
+	return "${g_exit_code}"
+}
+
+main "$@"

--- a/skills/proxmox/scripts/proxmox-sh-env-defaults
+++ b/skills/proxmox/scripts/proxmox-sh-env-defaults
@@ -1,0 +1,237 @@
+#!/bin/sh
+set -e
+set -u
+
+# proxmox-sh-env-defaults: suggest missing env values from API discovery
+#
+# Given a partial env file (at minimum: HOST + TOKEN), queries the API
+# to discover available resources and prints suggested values for any
+# unset variables. Does NOT modify the env file.
+#
+# Usage:
+#   proxmox-sh-env-defaults                    # uses current.env
+#   proxmox-sh-env-defaults --env <file>       # uses specific env
+#
+# Exit codes:
+#   0 - suggestions printed (may be empty if env is complete)
+#   1 - cannot connect or missing credentials
+
+g_env_file=""
+
+fn_usage() {
+	echo "Usage: proxmox-sh-env-defaults [--env <file>]"
+	echo ""
+	echo "Suggest values for missing env variables based on API discovery."
+}
+
+main() {
+	while test -n "${1:-}"; do
+		case "${1}" in
+		--env)
+			shift
+			g_env_file="${1:-}"
+			if test -z "${g_env_file}"; then
+				echo "ERROR: --env requires a file path" >&2
+				return 1
+			fi
+			;;
+		--help | -help | help)
+			fn_usage
+			return 0
+			;;
+		*)
+			echo "Unknown argument: ${1}" >&2
+			echo ""
+			fn_usage >&2
+			return 1
+			;;
+		esac
+		shift
+	done
+
+	if test -z "${g_env_file}"; then
+		if ! test -e ~/.config/proxmox-sh/current.env; then
+			echo "ERROR: no current.env and no --env flag" >&2
+			return 1
+		fi
+		g_env_file=~/.config/proxmox-sh/current.env
+	fi
+
+	# shellcheck disable=SC1090
+	. "${g_env_file}" || true
+
+	if test -z "${PROXMOX_HOST:-}" ||
+		test -z "${PROXMOX_TOKEN_ID:-}" ||
+		test -z "${PROXMOX_TOKEN_SECRET:-}"; then
+		echo "ERROR: need at least PROXMOX_HOST, PROXMOX_TOKEN_ID, PROXMOX_TOKEN_SECRET" >&2
+		return 1
+	fi
+
+	b_auth="Authorization: PVEAPIToken=${PROXMOX_TOKEN_ID}=${PROXMOX_TOKEN_SECRET}"
+	b_base_url="https://${PROXMOX_HOST}/api2/json"
+	b_curl="curl --max-time 10 --fail-with-body -sSL"
+
+	# Test connectivity
+	if ! ${b_curl} -H "${b_auth}" "${b_base_url}/version" >/dev/null 2>&1; then
+		echo "ERROR: cannot reach ${PROXMOX_HOST}" >&2
+		return 1
+	fi
+
+	# Fetch permissions (single call, covers pools/storages/sdn/nodes)
+	if ! b_perms="$(${b_curl} -H "${b_auth}" "${b_base_url}/access/permissions" 2>&1)"; then
+		echo "ERROR: cannot query permissions" >&2
+		return 1
+	fi
+
+	echo "# env-defaults"
+	printf 'env_file\t%s\n' "$(basename "${g_env_file}")"
+
+	b_suggest_count=0
+
+	# --- PROXMOX_TARGET_NODE ---
+	if test -z "${PROXMOX_TARGET_NODE:-}"; then
+		b_node="$(echo "${b_perms}" | jq -r '
+			[.data | to_entries[] | select(.key | startswith("/nodes/"))
+			| .key | ltrimstr("/nodes/") | split("/")[0]]
+			| unique | first // empty
+		')"
+		if test -z "${b_node}"; then
+			# Fall back to cluster/nodes
+			b_node="$(${b_curl} -H "${b_auth}" "${b_base_url}/nodes" 2>/dev/null |
+				jq -r '.data | sort_by(.node) | .[0].node // empty')" || true
+		fi
+		if test -n "${b_node}"; then
+			fn_suggest "PROXMOX_TARGET_NODE" "${b_node}" "first node visible"
+		fi
+	fi
+
+	# --- PROXMOX_RESOURCE_POOL ---
+	if test -z "${PROXMOX_RESOURCE_POOL:-}"; then
+		# Prefer *-active, then *-dev, then first pool with Pool.Allocate
+		b_pools="$(echo "${b_perms}" | jq -r '
+			[.data | to_entries[]
+			| select(.key | startswith("/pool/"))
+			| select(.value["Pool.Allocate"] == 1)
+			| .key | ltrimstr("/pool/")]
+			| sort | .[]
+		')"
+		b_pool=""
+		if test -n "${b_pools}"; then
+			b_pool="$(echo "${b_pools}" | grep -m1 '\-active$' || true)"
+			if test -z "${b_pool}"; then
+				b_pool="$(echo "${b_pools}" | grep -m1 '\-dev$' || true)"
+			fi
+			if test -z "${b_pool}"; then
+				b_pool="$(echo "${b_pools}" | head -1)"
+			fi
+		fi
+		if test -n "${b_pool}"; then
+			fn_suggest "PROXMOX_RESOURCE_POOL" "${b_pool}" "pool with Pool.Allocate"
+		fi
+	fi
+
+	# --- PROXMOX_VNET or PROXMOX_BRIDGE ---
+	if test -z "${PROXMOX_VNET:-}" && test -z "${PROXMOX_BRIDGE:-}"; then
+		b_zone="$(echo "${b_perms}" | jq -r '
+			[.data | to_entries[]
+			| select(.key | startswith("/sdn/zones/"))
+			| select(.value["SDN.Use"] == 1)
+			| .key | ltrimstr("/sdn/zones/") | split("/")[0]]
+			| unique | first // empty
+		')"
+		if test -n "${b_zone}"; then
+			# Try to find a vnet in this zone
+			b_vnet="$(${b_curl} -H "${b_auth}" "${b_base_url}/cluster/sdn/vnets" 2>/dev/null |
+				jq -r --arg z "${b_zone}" '.data[] | select(.zone == $z) | .vnet' | head -1)" || true
+			if test -n "${b_vnet}"; then
+				fn_suggest "PROXMOX_VNET" "${b_vnet}" "first vnet in zone ${b_zone}"
+			fi
+		fi
+	fi
+
+	# --- PROXMOX_TEMPLATE_STORAGE ---
+	if test -z "${PROXMOX_TEMPLATE_STORAGE:-}"; then
+		b_tmpl_storage="$(echo "${b_perms}" | jq -r '
+			[.data | to_entries[]
+			| select(.key | startswith("/storage/"))
+			| select(.value["Datastore.Audit"] == 1 or .value["Datastore.AllocateSpace"] == 1)
+			| .key | ltrimstr("/storage/")]
+			| sort | .[]
+		')"
+		if test -n "${b_tmpl_storage}"; then
+			# Check each for vztmpl content
+			b_found_storage=""
+			b_target_node="${PROXMOX_TARGET_NODE:-${b_node:-pve1}}"
+			for b_stor in ${b_tmpl_storage}; do
+				b_has_tmpl="$(${b_curl} -H "${b_auth}" \
+					"${b_base_url}/nodes/${b_target_node}/storage/${b_stor}/content?content=vztmpl" 2>/dev/null |
+					jq '.data | length' 2>/dev/null)" || true
+				if test -n "${b_has_tmpl}" && test "${b_has_tmpl}" -gt 0; then
+					b_found_storage="${b_stor}"
+					break
+				fi
+			done
+			if test -n "${b_found_storage}"; then
+				fn_suggest "PROXMOX_TEMPLATE_STORAGE" "${b_found_storage}" "has vztmpl content"
+			fi
+		fi
+	fi
+
+	# --- PROXMOX_TEMPLATE_DEFAULT ---
+	if test -z "${PROXMOX_TEMPLATE_DEFAULT:-}"; then
+		b_tmpl_stor="${PROXMOX_TEMPLATE_STORAGE:-${b_found_storage:-}}"
+		b_tmpl_node="${PROXMOX_TARGET_NODE:-${b_node:-pve1}}"
+		if test -n "${b_tmpl_stor}"; then
+			# Prefer ubuntu bnna, then ubuntu standard, then first template
+			b_templates="$(${b_curl} -H "${b_auth}" \
+				"${b_base_url}/nodes/${b_tmpl_node}/storage/${b_tmpl_stor}/content?content=vztmpl" 2>/dev/null |
+				jq -r '.data[].volid' | sort)" || true
+			if test -n "${b_templates}"; then
+				b_tmpl="$(echo "${b_templates}" | grep -m1 'ubuntu.*bnna' || true)"
+				if test -z "${b_tmpl}"; then
+					b_tmpl="$(echo "${b_templates}" | grep -m1 'ubuntu' || true)"
+				fi
+				if test -z "${b_tmpl}"; then
+					b_tmpl="$(echo "${b_templates}" | head -1)"
+				fi
+				if test -n "${b_tmpl}"; then
+					fn_suggest "PROXMOX_TEMPLATE_DEFAULT" "${b_tmpl}" "template preference: bnna > ubuntu > first"
+				fi
+			fi
+		fi
+	fi
+
+	# --- PROXMOX_ID_PREFIX ---
+	if test -z "${PROXMOX_ID_PREFIX:-}"; then
+		# Try to infer from existing VMs in the chosen pool
+		b_target_pool="${PROXMOX_RESOURCE_POOL:-${b_pool:-}}"
+		if test -n "${b_target_pool}"; then
+			b_prefix="$(${b_curl} -H "${b_auth}" "${b_base_url}/cluster/resources?type=vm" 2>/dev/null |
+				jq -r --arg p "${b_target_pool}" '
+					[.data[] | select(.pool == $p) | .vmid | tostring | .[:-3]]
+					| unique | first // empty
+				')" || true
+			if test -n "${b_prefix}"; then
+				fn_suggest "PROXMOX_ID_PREFIX" "${b_prefix}" "inferred from existing VMs in ${b_target_pool}"
+			fi
+		fi
+	fi
+
+	# Summary
+	echo ""
+	if test "${b_suggest_count}" -eq 0; then
+		echo "OK: env file appears complete"
+	else
+		printf 'suggestions\t%s\n' "${b_suggest_count}"
+	fi
+}
+
+fn_suggest() {
+	b_var="${1}"
+	b_val="${2}"
+	b_reason="${3}"
+	b_suggest_count=$((b_suggest_count + 1))
+	printf 'SUGGEST\t%s\t%s\t# %s\n' "${b_var}" "${b_val}" "${b_reason}"
+}
+
+main "$@"

--- a/skills/proxmox/scripts/proxmox-sh-profiles
+++ b/skills/proxmox/scripts/proxmox-sh-profiles
@@ -1,0 +1,106 @@
+#!/bin/sh
+set -e
+set -u
+
+# proxmox-sh-profiles: list env profiles for agent selection
+#
+# Output: numbered list of profiles with host, pools, and current marker.
+# Designed for the agent to present to the user as a pick list.
+#
+# Usage:
+#   proxmox-sh-profiles
+#
+# Exit codes:
+#   0 - profiles listed
+#   1 - no config dir
+#
+# AGENT: Present as a numbered pick list. Highlight which is [current].
+#   If only one profile exists, confirm it rather than asking.
+#   After selection, switch with: env-switch proxmox-sh <profile-name>
+
+fn_usage() {
+	echo "Usage: proxmox-sh-profiles"
+	echo ""
+	echo "List env profiles with host and pool summary."
+}
+
+main() {
+	case "${1:-}" in
+	--help | -help | help)
+		fn_usage
+		return 0
+		;;
+	-* | ?*)
+		echo "Unknown argument: ${1}" >&2
+		echo ""
+		fn_usage >&2
+		return 1
+		;;
+	esac
+
+	b_config_dir=~/.config/proxmox-sh
+
+	if ! test -d "${b_config_dir}"; then
+		echo "ERROR: ${b_config_dir} not found" >&2
+		return 1
+	fi
+
+	# Resolve current profile
+	b_current=""
+	if test -L "${b_config_dir}/current.env"; then
+		# shellcheck disable=SC2012
+		b_current="$(ls -l "${b_config_dir}/current.env" | sed 's;.*/;;')"
+	fi
+
+	echo "# profiles"
+	if test -n "${b_current}"; then
+		printf 'current\t%s\n' "${b_current}"
+	fi
+
+	# Dim host/pool columns when outputting to a terminal
+	b_dim=""
+	b_reset=""
+	if test -t 1; then
+		b_dim='\033[2m'
+		b_reset='\033[0m'
+	fi
+
+	echo ""
+	printf '# n\tprofile\thost\tpools\n'
+
+	b_n=0
+	for b_env in "${b_config_dir}"/*.env; do
+		b_name="$(basename "${b_env}")"
+		case "${b_name}" in
+		current.env | example.env | "*.env") continue ;;
+		esac
+
+		b_n=$((b_n + 1))
+
+		# Source in subshell to extract values
+		b_host=""
+		b_pools=""
+		b_host="$(
+			# shellcheck disable=SC1090
+			(. "${b_env}" 2>/dev/null || true; echo "${PROXMOX_HOST:-unknown}")
+		)"
+		b_pools="$(
+			# shellcheck disable=SC1090
+			(. "${b_env}" 2>/dev/null || true; echo "${PROXMOX_RESOURCE_POOL:-}")
+		)"
+
+		b_marker=""
+		if test "${b_name}" = "${b_current}"; then
+			b_marker=" [current]"
+		fi
+
+		# shellcheck disable=SC2059
+		printf "%s\t%s%s\t${b_dim}%s\t%s${b_reset}\n" "${b_n}" "${b_name}" "${b_marker}" "${b_host}" "${b_pools}"
+	done
+
+	if test "${b_n}" -eq 0; then
+		echo "# (none)"
+	fi
+}
+
+main "$@"

--- a/skills/proxmox/scripts/proxmox-sh-resources
+++ b/skills/proxmox/scripts/proxmox-sh-resources
@@ -1,0 +1,476 @@
+#!/bin/sh
+set -e
+set -u
+
+# proxmox-sh-resources: list Proxmox infrastructure for agent use
+#
+# Output format: # section headers, TSV data rows, OK:/WARN:/ERROR: status lines.
+# Designed for agent consumption; colored summary at the end for humans.
+#
+# Usage:
+#   proxmox-sh-resources            # fast: 3 API calls (permissions + VMs)
+#   proxmox-sh-resources --detail   # full: 8+ API calls, all details
+#
+# Exit codes:
+#   0 - listing completed
+#   1 - cannot connect or missing env
+#
+# AGENT: Don't dump the full output to the user. Summarize:
+#   - N VMs running / N stopped
+#   - Available pools (highlight *-active and *-dev)
+#   - Any warnings or errors
+#   Use pool list to validate PROXMOX_RESOURCE_POOL before create.
+#   If the env pool isn't in the list, tell the user and pick from available pools.
+#   On 403 errors: likely a token permission issue. Read references/minimum-permissions.csv.
+
+g_exit_code=0
+g_detail=false
+g_env_file=""
+
+fn_ok() {
+	printf 'OK: %s\n' "$1"
+}
+
+fn_warn() {
+	printf 'WARN: %s\n' "$1" >&2
+}
+
+fn_err() {
+	printf 'ERROR: %s\n' "$1" >&2
+	g_exit_code=1
+}
+
+# ----------------------------------------
+# Load env and connect
+# ----------------------------------------
+fn_init() {
+	if test -n "${g_env_file}"; then
+		if ! test -e "${g_env_file}"; then
+			fn_err "env file not found: ${g_env_file}"
+			return 1
+		fi
+	else
+		if ! test -e ~/.config/proxmox-sh/current.env; then
+			fn_err "no current.env - run proxmox-sh-doctor first"
+			return 1
+		fi
+		g_env_file=~/.config/proxmox-sh/current.env
+	fi
+
+	# shellcheck disable=SC1090
+	. "${g_env_file}" || true
+
+	if test -z "${PROXMOX_HOST:-}" ||
+		test -z "${PROXMOX_TOKEN_ID:-}" ||
+		test -z "${PROXMOX_TOKEN_SECRET:-}"; then
+		fn_err "missing HOST/TOKEN vars - run proxmox-sh-doctor first"
+		return 1
+	fi
+
+	g_auth="Authorization: PVEAPIToken=${PROXMOX_TOKEN_ID}=${PROXMOX_TOKEN_SECRET}"
+	g_base_url="https://${PROXMOX_HOST}/api2/json"
+	g_curl="curl --max-time 10 --fail-with-body -sSL"
+
+	if ! b_version="$(${g_curl} -H "${g_auth}" "${g_base_url}/version" 2>&1)"; then
+		fn_err "cannot reach ${PROXMOX_HOST}"
+		echo "${b_version}" >&2
+		return 1
+	fi
+
+	b_pve_version="$(echo "${b_version}" | jq -r '.data.version // "unknown"')"
+
+	echo "# proxmox-sh-resources"
+	b_mode="fast"
+	if test "${g_detail}" = "true"; then
+		b_mode="detail"
+	fi
+	b_profile="$(basename "${g_env_file}")"
+	printf 'mode\t%s\n' "${b_mode}"
+	printf 'profile\t%s\n' "${b_profile}"
+	printf 'host\t%s\n' "${PROXMOX_HOST}"
+	printf 'pve\t%s\n' "${b_pve_version}"
+}
+
+# ========================================
+# Fast mode
+# ========================================
+fn_fast() {
+	if ! g_perms="$(${g_curl} -H "${g_auth}" "${g_base_url}/access/permissions" 2>&1)"; then
+		fn_err "cannot query permissions"
+		return 1
+	fi
+
+	g_granted="$(echo "${g_perms}" | jq '
+		# Map full permission lists to short capability flags
+		def caps:
+			. as $p |
+			(if ($p | any(startswith("VM.Allocate"))) then ["vm-alloc"] else [] end) +
+			(if ($p | any(startswith("VM.PowerMgmt"))) then ["vm-manage"] else [] end) +
+			(if ($p | any(startswith("Pool.Allocate"))) then ["pool-alloc"] else [] end) +
+			(if ($p | any(startswith("Datastore.AllocateSpace"))) then ["ds-alloc"] else [] end) +
+			(if ($p | any(startswith("Datastore.AllocateTemplate"))) then ["ds-tmpl"] else [] end) +
+			(if ($p | any(startswith("SDN.Use"))) then ["sdn-use"] else [] end) +
+			(if ($p | any(startswith("SDN.Allocate"))) then ["sdn-alloc"] else [] end) +
+			(if ($p | any(test("Audit"))) then ["audit"] else [] end) +
+			(if ($p | any(startswith("Sys."))) then ["sys"] else [] end)
+			| unique;
+		[.data | to_entries[]
+			| select(.value | to_entries | map(select(.value == 1)) | length > 0)
+			| {
+				path: .key,
+				perms: [.value | to_entries[] | select(.value == 1) | .key] | sort,
+				caps: ([.value | to_entries[] | select(.value == 1) | .key] | caps)
+			}
+		] | sort_by(.path)
+	')"
+
+	fn_fast_pools
+	fn_fast_storages
+	fn_fast_vms
+	fn_fast_sdn
+	fn_fast_nodes
+}
+
+fn_fast_pools() {
+	echo ""
+	echo "# pools"
+	echo "# AGENT: these are the pools you can use for VM creation."
+	echo "# AGENT: pick from this list, not from the env file -- the env pool may not exist."
+	echo "# AGENT: *-active pools are for running workloads, *-dev for development."
+	printf '# pool\tcapabilities\n'
+
+	b_pools="$(echo "${g_granted}" | jq -r '.[] | select(.path | startswith("/pool/")) | [(.path | ltrimstr("/pool/")), (.caps | join(","))] | @tsv')"
+	if test -z "${b_pools}"; then
+		echo "# (none)"
+		echo "# AGENT: no pools visible. The token may lack Pool.Allocate permission."
+		return
+	fi
+	echo "${b_pools}"
+
+	echo ""
+	echo "# pool-conventions"
+	for b_suffix in active dev prod offline; do
+		b_matches="$(echo "${b_pools}" | grep -c "\-${b_suffix}	" || true)"
+		if test "${b_matches}" -gt 0; then
+			printf '*-%s\t%s\n' "${b_suffix}" "${b_matches}"
+		fi
+	done
+}
+
+fn_fast_storages() {
+	echo ""
+	echo "# storages"
+	echo "# AGENT: ds-alloc = can allocate disk space, ds-tmpl = can store templates."
+	printf '# storage\tcapabilities\n'
+
+	b_storages="$(echo "${g_granted}" | jq -r '.[] | select(.path | startswith("/storage/")) | [(.path | ltrimstr("/storage/")), (.caps | join(","))] | @tsv')"
+	if test -z "${b_storages}"; then
+		echo "# (none)"
+		return
+	fi
+	echo "${b_storages}"
+}
+
+fn_fast_vms() {
+	echo ""
+	echo "# vms"
+	echo "# AGENT: summarize as 'N running, M stopped'. Only list individual VMs if the user asks."
+
+	# Always call cluster/resources for names and status
+	if ! b_resources="$(${g_curl} -H "${g_auth}" "${g_base_url}/cluster/resources?type=vm" 2>&1)"; then
+		fn_warn "cannot fetch VM details"
+		# Fall back to VMID list from permissions
+		b_all_vmids="$(echo "${g_perms}" | jq -r '[.data | to_entries[] | select(.key | startswith("/vms/")) | .key | ltrimstr("/vms/")] | sort | .[]')"
+		if test -n "${b_all_vmids}"; then
+			echo "# vmid (no details)"
+			echo "${b_all_vmids}"
+		else
+			echo "# (none)"
+		fi
+		return
+	fi
+
+	b_count="$(echo "${b_resources}" | jq '.data | length')"
+	b_running="$(echo "${b_resources}" | jq '[.data[] | select(.status == "running")] | length')"
+	b_stopped="$(echo "${b_resources}" | jq '[.data[] | select(.status == "stopped")] | length')"
+	printf 'total\t%s\n' "${b_count}"
+	printf 'running\t%s\n' "${b_running}"
+	printf 'stopped\t%s\n' "${b_stopped}"
+
+	if test "${b_count}" -eq 0; then
+		return
+	fi
+
+	echo ""
+	printf '# vmid\tname\tstatus\tnode\tpool\n'
+	echo "${b_resources}" | jq -r '
+		.data | sort_by(.vmid) | .[]
+		| [(.vmid | tostring), (.name // "unnamed"), .status, .node, (.pool // "none")]
+		| @tsv
+	'
+}
+
+fn_fast_sdn() {
+	echo ""
+	echo "# sdn-zones"
+	printf '# zone\tcapabilities\n'
+
+	b_zones="$(echo "${g_granted}" | jq -r '.[] | select(.path | startswith("/sdn/zones/")) | [(.path | ltrimstr("/sdn/zones/")), (.caps | join(","))] | @tsv')"
+	if test -z "${b_zones}"; then
+		echo "# (none)"
+	else
+		echo "${b_zones}"
+	fi
+}
+
+fn_fast_nodes() {
+	echo ""
+	echo "# nodes"
+
+	b_nodes="$(echo "${g_granted}" | jq -r '.[] | select(.path | startswith("/nodes")) | [.path, (.caps | join(","))] | @tsv')"
+	if test -z "${b_nodes}"; then
+		echo "# (none)"
+	else
+		echo "${b_nodes}"
+	fi
+	echo "# (run with --detail for CPU/memory metrics)"
+}
+
+# ========================================
+# Full mode
+# ========================================
+
+fn_list_pools() {
+	echo ""
+	echo "# pools"
+	printf '# pool\tmembers\n'
+
+	if ! b_pools="$(${g_curl} -H "${g_auth}" "${g_base_url}/pools" 2>&1)"; then
+		fn_warn "cannot list pools"
+		return
+	fi
+
+	b_pool_list="$(echo "${b_pools}" | jq -r '.data[].poolid' | sort)"
+	if test -z "${b_pool_list}"; then
+		echo "# (none)"
+		return
+	fi
+
+	echo "${b_pool_list}" | while read -r b_pool; do
+		b_member_count="$(
+			echo "${b_pools}" |
+				jq -r --arg p "${b_pool}" '.data[] | select(.poolid == $p) | (.members // []) | length'
+		)"
+		printf '%s\t%s\n' "${b_pool}" "${b_member_count}"
+	done
+
+	echo ""
+	echo "# pool-conventions"
+	for b_suffix in active dev prod offline; do
+		b_matches="$(echo "${b_pool_list}" | grep -c "\-${b_suffix}$" || true)"
+		if test "${b_matches}" -gt 0; then
+			printf '*-%s\t%s\n' "${b_suffix}" "${b_matches}"
+		fi
+	done
+}
+
+fn_list_storages() {
+	echo ""
+	echo "# storages"
+	printf '# storage\ttype\tcontent\n'
+
+	if ! b_storages="$(${g_curl} -H "${g_auth}" "${g_base_url}/storage" 2>&1)"; then
+		fn_warn "cannot list storages"
+		return
+	fi
+
+	echo "${b_storages}" | jq -r '.data | sort_by(.storage) | .[] | [.storage, .type, (.content // "n/a")] | @tsv'
+}
+
+fn_list_resources() {
+	echo ""
+	echo "# vms"
+
+	if ! b_resources="$(${g_curl} -H "${g_auth}" "${g_base_url}/cluster/resources?type=vm" 2>&1)"; then
+		fn_warn "cannot list cluster resources"
+		return
+	fi
+
+	b_count="$(echo "${b_resources}" | jq '.data | length')"
+	b_running="$(echo "${b_resources}" | jq '[.data[] | select(.status == "running")] | length')"
+	b_stopped="$(echo "${b_resources}" | jq '[.data[] | select(.status == "stopped")] | length')"
+	printf 'total\t%s\n' "${b_count}"
+	printf 'running\t%s\n' "${b_running}"
+	printf 'stopped\t%s\n' "${b_stopped}"
+
+	if test "${b_count}" -eq 0; then
+		return
+	fi
+
+	echo ""
+	printf '# vmid\tname\tstatus\tnode\tpool\n'
+	echo "${b_resources}" | jq -r '
+		.data | sort_by(.vmid) | .[]
+		| [(.vmid | tostring), (.name // "unnamed"), .status, .node, (.pool // "none")]
+		| @tsv
+	'
+}
+
+fn_list_sdn() {
+	echo ""
+	echo "# sdn-zones"
+	printf '# zone\ttype\n'
+
+	if ! b_zones="$(${g_curl} -H "${g_auth}" "${g_base_url}/cluster/sdn/zones" 2>&1)"; then
+		fn_warn "cannot list SDN zones"
+		return
+	fi
+
+	b_zone_count="$(echo "${b_zones}" | jq '.data | length')"
+	if test "${b_zone_count}" -eq 0; then
+		echo "# (none)"
+	else
+		echo "${b_zones}" | jq -r '.data | sort_by(.zone) | .[] | [.zone, .type] | @tsv'
+	fi
+
+	echo ""
+	echo "# sdn-vnets"
+	printf '# vnet\tzone\ttag\n'
+
+	if ! b_vnets="$(${g_curl} -H "${g_auth}" "${g_base_url}/cluster/sdn/vnets" 2>&1)"; then
+		fn_warn "cannot list SDN vnets"
+		return
+	fi
+
+	b_vnet_count="$(echo "${b_vnets}" | jq '.data | length')"
+	if test "${b_vnet_count}" -eq 0; then
+		echo "# (none)"
+	else
+		echo "${b_vnets}" | jq -r '.data | sort_by(.vnet) | .[] | [.vnet, .zone, (.tag // "none" | tostring)] | @tsv'
+	fi
+}
+
+fn_list_nodes() {
+	echo ""
+	echo "# nodes"
+	printf '# node\tstatus\tcpu_pct\tmem_gb\tmaxmem_gb\n'
+
+	if ! b_nodes="$(${g_curl} -H "${g_auth}" "${g_base_url}/nodes" 2>&1)"; then
+		fn_warn "cannot list nodes"
+		return
+	fi
+
+	echo "${b_nodes}" | jq -r '
+		.data | sort_by(.node) | .[]
+		| [
+			.node,
+			.status,
+			(.cpu // 0 | . * 100 | floor | tostring),
+			((.mem // 0) / 1073741824 | . * 10 | floor / 10 | tostring),
+			((.maxmem // 0) / 1073741824 | . * 10 | floor / 10 | tostring)
+		] | @tsv
+	'
+}
+
+fn_list_templates() {
+	echo ""
+	echo "# templates"
+
+	b_node="${PROXMOX_TARGET_NODE:-pve1}"
+	b_tmpl_storage="${PROXMOX_TEMPLATE_STORAGE:-}"
+
+	if test -z "${b_tmpl_storage}"; then
+		fn_warn "PROXMOX_TEMPLATE_STORAGE not set"
+		return
+	fi
+
+	printf 'storage\t%s\n' "${b_tmpl_storage}"
+	printf 'node\t%s\n' "${b_node}"
+
+	if ! b_content="$(${g_curl} -H "${g_auth}" \
+		"${g_base_url}/nodes/${b_node}/storage/${b_tmpl_storage}/content?content=vztmpl" 2>&1)"; then
+		fn_warn "cannot list templates from ${b_tmpl_storage}"
+		return
+	fi
+
+	echo ""
+	printf '# volid\tsize_mb\n'
+	echo "${b_content}" | jq -r '
+		.data | sort_by(.volid) | .[]
+		| [.volid, (.size // 0 | . / 1048576 | floor | tostring)]
+		| @tsv
+	'
+
+	if test -n "${PROXMOX_TEMPLATE_DEFAULT:-}"; then
+		b_default_match="$(echo "${b_content}" | jq -r --arg t "${PROXMOX_TEMPLATE_DEFAULT}" '
+			.data[] | select(.volid | endswith($t)) | .volid
+		')"
+		if test -n "${b_default_match}"; then
+			fn_ok "default template '${PROXMOX_TEMPLATE_DEFAULT}' found"
+		else
+			fn_warn "default template '${PROXMOX_TEMPLATE_DEFAULT}' not found"
+		fi
+	fi
+}
+
+# ----------------------------------------
+# Main
+# ----------------------------------------
+fn_usage() {
+	echo "Usage: proxmox-sh-resources [--detail] [--env <file>]"
+	echo ""
+	echo "List Proxmox infrastructure: pools, storages, VMs, SDN, nodes."
+	echo ""
+	echo "  --detail       8+ API calls: node metrics, vnet details, pool members, templates"
+	echo "  --env <file>   source this env file instead of current.env"
+}
+
+main() {
+	while test -n "${1:-}"; do
+		case "${1}" in
+		--detail)
+			g_detail=true
+			;;
+		--env)
+			shift
+			g_env_file="${1:-}"
+			if test -z "${g_env_file}"; then
+				echo "ERROR: --env requires a file path" >&2
+				echo ""
+				fn_usage >&2
+				return 1
+			fi
+			;;
+		--help | -help | help)
+			fn_usage
+			return 0
+			;;
+		*)
+			echo "Unknown flag: ${1}" >&2
+			echo ""
+			fn_usage >&2
+			return 1
+			;;
+		esac
+		shift
+	done
+
+	fn_init || return 1
+
+	if test "${g_detail}" = "true"; then
+		fn_list_pools
+		fn_list_storages
+		fn_list_resources
+		fn_list_sdn
+		fn_list_nodes
+		fn_list_templates
+	else
+		fn_fast
+	fi
+
+	echo ""
+
+	return "${g_exit_code}"
+}
+
+main "$@"

--- a/skills/proxmox/scripts/proxmox-sh-resources-all
+++ b/skills/proxmox/scripts/proxmox-sh-resources-all
@@ -1,0 +1,120 @@
+#!/bin/sh
+set -e
+set -u
+
+# proxmox-sh-resources-all: scan all env profiles with proxmox-sh-resources
+#
+# Iterates *.env files in the config dir, runs proxmox-sh-resources for each.
+# Individual profile failures are reported but do not stop the scan.
+#
+# Usage:
+#   proxmox-sh-resources-all                          # scan ~/.config/proxmox-sh/
+#   proxmox-sh-resources-all /path/to/envs/           # scan a specific dir
+#
+# Exit codes:
+#   0 - all profiles scanned
+#   1 - no profiles found or all failed
+#   2 - some profiles failed
+
+g_script_dir="$(cd "$(dirname "$0")" && pwd)"
+g_config_dir=""
+g_ok_count=0
+g_fail_count=0
+g_skip_count=0
+
+fn_usage() {
+	echo "Usage: proxmox-sh-resources-all [<env-dir>]"
+	echo ""
+	echo "Scan all .env profiles with proxmox-sh-resources."
+	echo ""
+	echo "  <env-dir>   directory of .env files (default: ~/.config/proxmox-sh/)"
+}
+
+fn_scan_profile() {
+	b_env_file="${1}"
+	b_name="$(basename "${b_env_file}")"
+
+	echo ""
+	echo "# ========================================"
+	printf '# profile: %s\n' "${b_name}"
+	echo "# ========================================"
+
+	if ! sh "${g_script_dir}/proxmox-sh-resources" --env "${b_env_file}" 2>&1; then
+		printf 'ERROR: %s failed\n' "${b_name}" >&2
+		g_fail_count=$((g_fail_count + 1))
+		return
+	fi
+
+	g_ok_count=$((g_ok_count + 1))
+}
+
+main() {
+	case "${1:-}" in
+	--help | -help | help)
+		fn_usage
+		return 0
+		;;
+	-* | ?*)
+		if test -d "${1}"; then
+			g_config_dir="${1}"
+		else
+			echo "Unknown argument: ${1}" >&2
+			echo ""
+			fn_usage >&2
+			return 1
+		fi
+		;;
+	esac
+
+	if test -z "${g_config_dir}"; then
+		g_config_dir=~/.config/proxmox-sh
+	fi
+
+	if ! test -d "${g_config_dir}"; then
+		echo "ERROR: directory not found: ${g_config_dir}" >&2
+		return 1
+	fi
+
+	echo "# proxmox-sh-resources-all"
+	printf 'config_dir\t%s\n' "${g_config_dir}"
+
+	b_profile_count=0
+	for b_env in "${g_config_dir}"/*.env; do
+		b_name="$(basename "${b_env}")"
+		if test "${b_name}" = "*.env"; then
+			echo "ERROR: no .env files found in ${g_config_dir}" >&2
+			return 1
+		fi
+		case "${b_name}" in
+		current.env | example.env)
+			g_skip_count=$((g_skip_count + 1))
+			continue
+			;;
+		esac
+		b_profile_count=$((b_profile_count + 1))
+		fn_scan_profile "${b_env}"
+	done
+
+	if test "${b_profile_count}" -eq 0; then
+		echo "ERROR: no profiles found in ${g_config_dir}" >&2
+		return 1
+	fi
+
+	# Summary
+	echo ""
+	echo "# summary"
+	printf 'profiles\t%s\n' "${b_profile_count}"
+	printf 'ok\t%s\n' "${g_ok_count}"
+	printf 'failed\t%s\n' "${g_fail_count}"
+	printf 'skipped\t%s\n' "${g_skip_count}"
+
+	if test "${g_ok_count}" -eq 0; then
+		return 1
+	fi
+	if test "${g_fail_count}" -gt 0; then
+		return 2
+	fi
+	return 0
+}
+
+main "$@"

--- a/skills/proxmox/scripts/proxmox-sh-ssh-check
+++ b/skills/proxmox/scripts/proxmox-sh-ssh-check
@@ -1,0 +1,105 @@
+#!/bin/sh
+set -e
+set -u
+
+# proxmox-sh-ssh-check: verify SSH config for direct-IP domain access
+#
+# Checks ~/.ssh/config for the wildcard Host entry needed to SSH into
+# Proxmox VMs via sclient. Prints the entry to add if missing.
+#
+# Usage:
+#   proxmox-sh-ssh-check                    # uses DIRECT_IP_DOMAIN from current.env
+#   proxmox-sh-ssh-check vms.example.net    # check a specific domain
+#
+# Exit codes:
+#   0 - wildcard entry found
+#   1 - missing or no domain
+#
+# AGENT: On OK, proceed silently. On missing entry, show the user
+#   what needs to be added and ask permission before touching SSH config.
+#   Suggest ~/.ssh/config.d/proxmox-sh.sshconfig as the target file.
+
+fn_usage() {
+	echo "Usage: proxmox-sh-ssh-check [<direct-ip-domain>]"
+	echo ""
+	echo "Verify SSH config has wildcard entry for direct-IP domain access."
+}
+
+main() {
+	case "${1:-}" in
+	--help | -help | help)
+		fn_usage
+		return 0
+		;;
+	esac
+
+	b_domain="${1:-}"
+
+	if test -z "${b_domain}"; then
+		if ! test -e ~/.config/proxmox-sh/current.env; then
+			echo "ERROR: no domain arg and no current.env" >&2
+			return 1
+		fi
+		# shellcheck disable=SC1090
+		. ~/.config/proxmox-sh/current.env || true
+		b_domain="${DIRECT_IP_DOMAIN:-}"
+	fi
+
+	if test -z "${b_domain}"; then
+		echo "ERROR: DIRECT_IP_DOMAIN not set and no domain arg" >&2
+		return 1
+	fi
+
+	echo "# ssh-check"
+	printf 'domain\t%s\n' "${b_domain}"
+
+	b_pattern="*.${b_domain}"
+
+	if ! test -f ~/.ssh/config; then
+		echo "MISSING: ~/.ssh/config does not exist"
+		fn_print_needed "${b_pattern}" "${b_domain}"
+		return 1
+	fi
+
+	# Search ~/.ssh/config and any Include'd files in config.d
+	b_ssh_files="$(find ~/.ssh -name '*.sshconfig' -o -name 'config' 2>/dev/null)"
+
+	# Look for Host *.<domain> across all ssh config files
+	# Use grep -F because b_pattern contains a literal * (e.g. *.vms.example.com)
+	b_match_file=""
+	if test -n "${b_ssh_files}"; then
+		b_match_file="$(echo "${b_ssh_files}" | xargs grep -lF "${b_pattern}" 2>/dev/null | head -1)" || true
+	fi
+
+	if test -n "${b_match_file}"; then
+		printf 'OK: wildcard entry found for %s in %s\n' "${b_pattern}" "${b_match_file}"
+
+		# Also check sclient is in the ProxyCommand
+		if grep -A2 -F "${b_pattern}" "${b_match_file}" | grep -q "sclient"; then
+			echo "OK: sclient ProxyCommand present"
+		else
+			echo "WARN: Host entry exists but no sclient ProxyCommand"
+		fi
+		return 0
+	fi
+
+	echo "MISSING: no Host entry for ${b_pattern}"
+	fn_print_needed "${b_pattern}" "${b_domain}"
+	return 1
+}
+
+fn_print_needed() {
+	b_pattern="${1}"
+	b_domain="${2}"
+
+	b_target_file=~/.ssh/config.d/proxmox-sh.sshconfig
+
+	echo ""
+	echo "# add-to-ssh-config"
+	printf 'file\t%s\n' "${b_target_file}"
+	echo ""
+	printf 'Host %s\n' "${b_pattern}"
+	printf '    ProxyCommand sclient --alpn ssh %%h\n'
+}
+
+main "$@"

--- a/skills/proxmox/scripts/proxmox-sh-ssh-wait
+++ b/skills/proxmox/scripts/proxmox-sh-ssh-wait
@@ -1,0 +1,151 @@
+#!/bin/sh
+set -e
+set -u
+
+# proxmox-sh-ssh-wait: wait for SSH readiness after container creation
+#
+# Output: TSV with user and host on success.
+# Designed for the agent to confirm SSH access post-create.
+#
+# Usage:
+#   proxmox-sh-ssh-wait <direct-ip-domain> [<friendly-domain>]
+#
+# Examples (IP 10.11.4.209, DIRECT_IP_DOMAIN=vms.example.com):
+#   proxmox-sh-ssh-wait tls-10-11-4-209.vms.example.com
+#   proxmox-sh-ssh-wait tls-10-11-4-209.vms.example.com dev-209.example.com
+#
+# Phase 1: Wait for SSH on the direct-IP domain (7s/15s/15s backoff).
+# Phase 2: If a friendly domain is given, poll DNS propagation (max 20s).
+#
+# If the friendly domain fails to resolve, the script prints a WARN
+# instructing the agent to verify the DNS record was created correctly
+# (CNAME for subdomains, A+SRV for apex domains).
+#
+# Exit codes:
+#   0 - SSH ready on direct-IP (friendly domain may have warned)
+#   1 - SSH not ready after retries
+#
+# AGENT: After this script succeeds, present the user a summary table:
+#   CTID, OS, user, direct-IP domain, friendly domain (if set), ssh command.
+#   On DNS WARN: verify the record was created correctly using domainpanel.
+#     - Subdomain: check CNAME points to the tls- direct-IP domain
+#     - Apex domain: check A record + SRV record (apex only, not subdomains)
+
+fn_usage() {
+	echo "Usage: proxmox-sh-ssh-wait <direct-ip-domain> [<friendly-domain>]"
+	echo ""
+	echo "Wait for SSH readiness after container creation."
+	echo "Tries root first, then app if auth denied."
+	echo "If friendly domain given, polls DNS propagation (max 20s)."
+}
+
+fn_try_ssh() {
+	a_user="${1}"
+	a_host="${2}"
+	ssh -o ConnectTimeout=5 \
+		-o StrictHostKeyChecking=accept-new \
+		-o BatchMode=yes \
+		"${a_user}@${a_host}" 'hostname' 2>/dev/null
+}
+
+fn_try_users() {
+	a_host="${1}"
+
+	# Try root first (standard/default templates)
+	if b_hostname="$(fn_try_ssh root "${a_host}")"; then
+		echo "root"
+		return 0
+	fi
+
+	# If SSH responded but auth failed, try app (custom/bnna templates)
+	sleep 2
+	if b_hostname="$(fn_try_ssh app "${a_host}")"; then
+		echo "app"
+		return 0
+	fi
+
+	return 1
+}
+
+fn_wait_dns() {
+	a_friendly="${1}"
+	a_user="${2}"
+
+	echo ""
+	echo "# dns-check"
+	printf 'friendly\t%s\n' "${a_friendly}"
+
+	b_elapsed=0
+	while test "${b_elapsed}" -lt 20; do
+		if b_hostname="$(fn_try_ssh "${a_user}" "${a_friendly}")"; then
+			printf 'ssh\tOK\n'
+			return 0
+		fi
+		echo "# waiting 5s for DNS..."
+		sleep 5
+		b_elapsed=$((b_elapsed + 5))
+	done
+
+	echo "WARN: friendly domain not reachable after 20s" >&2
+	echo "WARN: agent should verify DNS records:" >&2
+	echo "WARN:   subdomain => check CNAME points to direct-IP domain" >&2
+	echo "WARN:   apex domain => check A record + SRV record" >&2
+	printf 'ssh\tFAIL\n'
+	return 1
+}
+
+main() {
+	case "${1:-}" in
+	--help | -help | help)
+		fn_usage
+		return 0
+		;;
+	"")
+		echo "ERROR: direct-ip-domain required" >&2
+		echo ""
+		fn_usage >&2
+		return 1
+		;;
+	esac
+
+	b_host="${1}"
+	b_friendly="${2:-}"
+
+	echo "# ssh-wait"
+	printf 'target\t%s\n' "${b_host}"
+
+	# Phase 1: wait for SSH on direct-IP domain
+	b_user=""
+
+	echo "# waiting 7s..."
+	sleep 7
+	b_user="$(fn_try_users "${b_host}")" || true
+
+	if test -z "${b_user}"; then
+		echo "# waiting 15s..."
+		sleep 15
+		b_user="$(fn_try_users "${b_host}")" || true
+	fi
+
+	if test -z "${b_user}"; then
+		echo "# waiting 15s..."
+		sleep 15
+		b_user="$(fn_try_users "${b_host}")" || true
+	fi
+
+	if test -z "${b_user}"; then
+		echo "ERROR: SSH not ready after 37s" >&2
+		return 1
+	fi
+
+	printf 'user\t%s\n' "${b_user}"
+	printf 'host\t%s\n' "${b_host}"
+	echo "# OK"
+
+	# Phase 2: if friendly domain given, poll DNS propagation
+	if test -n "${b_friendly}"; then
+		fn_wait_dns "${b_friendly}" "${b_user}" || true
+	fi
+}
+
+main "$@"

--- a/skills/proxmox/scripts/proxmox-sh-templates
+++ b/skills/proxmox/scripts/proxmox-sh-templates
@@ -1,0 +1,167 @@
+#!/bin/sh
+set -e
+set -u
+
+# proxmox-sh-templates: list available OS templates for agent selection
+#
+# Output: numbered list of vztmpl/ paths with init system and variant tags.
+# Designed for the agent to present to the user as a pick list.
+#
+# Usage:
+#   proxmox-sh-templates                    # uses current.env
+#   proxmox-sh-templates --env <file>       # uses specific env
+#
+# Exit codes:
+#   0 - templates listed
+#   1 - cannot connect or missing env
+#
+# AGENT: Present as a numbered pick list. Curate for the user:
+#   - Trim older versions; keep only the newest of each distro
+#   - Highlight "bnna" and "custom" variants (preferred over standard)
+#   - Mark the "default" tag from the env
+#   - Callout init system differences: systemd (most services), openrc
+#     (minimal/lightweight), sysvinit (no-systemd preference)
+#   - Suggest a reasonable default but let the user choose
+#   - Use formatting (bold, dim) to make types visually distinct
+
+g_env_file=""
+
+fn_usage() {
+	echo "Usage: proxmox-sh-templates [--env <file>]"
+	echo ""
+	echo "List available OS templates with init system and variant tags."
+}
+
+main() {
+	while test -n "${1:-}"; do
+		case "${1}" in
+		--env)
+			shift
+			g_env_file="${1:-}"
+			if test -z "${g_env_file}"; then
+				echo "ERROR: --env requires a file path" >&2
+				echo ""
+				fn_usage >&2
+				return 1
+			fi
+			;;
+		--help | -help | help)
+			fn_usage
+			return 0
+			;;
+		*)
+			echo "Unknown argument: ${1}" >&2
+			echo ""
+			fn_usage >&2
+			return 1
+			;;
+		esac
+		shift
+	done
+
+	if test -z "${g_env_file}"; then
+		if ! test -e ~/.config/proxmox-sh/current.env; then
+			echo "ERROR: no current.env and no --env flag" >&2
+			return 1
+		fi
+		g_env_file=~/.config/proxmox-sh/current.env
+	fi
+
+	# shellcheck disable=SC1090
+	. "${g_env_file}" || true
+
+	if test -z "${PROXMOX_HOST:-}" ||
+		test -z "${PROXMOX_TOKEN_ID:-}" ||
+		test -z "${PROXMOX_TOKEN_SECRET:-}"; then
+		echo "ERROR: missing HOST/TOKEN vars" >&2
+		return 1
+	fi
+
+	b_node="${PROXMOX_TARGET_NODE:-pve1}"
+	b_default="${PROXMOX_TEMPLATE_DEFAULT:-}"
+
+	b_auth="Authorization: PVEAPIToken=${PROXMOX_TOKEN_ID}=${PROXMOX_TOKEN_SECRET}"
+	b_base_url="https://${PROXMOX_HOST}/api2/json"
+	b_curl="curl --max-time 10 --fail-with-body -sSL"
+
+	# Find all storages that support vztmpl content
+	if ! b_storages="$(${b_curl} -H "${b_auth}" \
+		"${b_base_url}/nodes/${b_node}/storage" 2>&1)"; then
+		echo "ERROR: cannot list storages" >&2
+		return 1
+	fi
+
+	b_tmpl_storages="$(echo "${b_storages}" | jq -r '
+		.data[] | select(.content // "" | split(",") | any(. == "vztmpl"))
+		| .storage
+	' | sort)"
+
+	if test -z "${b_tmpl_storages}"; then
+		echo "ERROR: no storages with vztmpl content" >&2
+		return 1
+	fi
+
+	echo "# templates"
+	printf 'node\t%s\n' "${b_node}"
+	if test -n "${b_default}"; then
+		printf 'default\t%s\n' "${b_default}"
+	fi
+
+	# Collect volids from all accessible storages
+	b_all_volids=""
+	for b_stor in ${b_tmpl_storages}; do
+		b_content="$(${b_curl} -H "${b_auth}" \
+			"${b_base_url}/nodes/${b_node}/storage/${b_stor}/content?content=vztmpl" 2>/dev/null)" || continue
+		b_volids="$(echo "${b_content}" | jq -r '.data[].volid' 2>/dev/null)" || continue
+		if test -n "${b_volids}"; then
+			if test -n "${b_all_volids}"; then
+				b_all_volids="$(printf '%s\n%s' "${b_all_volids}" "${b_volids}")"
+			else
+				b_all_volids="${b_volids}"
+			fi
+		fi
+	done
+
+	if test -z "${b_all_volids}"; then
+		echo "# (none)"
+		return
+	fi
+
+	# Deduplicate by template name (prefer configured storage), sort
+	b_all_volids="$(echo "${b_all_volids}" | sort -t: -k2 -u)"
+
+	echo ""
+	printf '# n\ttemplate\tinit\tvariant\n'
+
+	b_n=0
+	echo "${b_all_volids}" | while read -r b_volid; do
+		b_n=$((b_n + 1))
+
+		# Strip storage prefix for display
+		b_tmpl="$(echo "${b_volid}" | sed 's;^[^:]*:;;')"
+
+		# Detect init system
+		b_init="unknown"
+		case "${b_tmpl}" in
+		*ubuntu* | *debian*) b_init="systemd" ;;
+		*alpine*) b_init="openrc" ;;
+		*centos* | *rocky* | *fedora* | *almalinux*) b_init="systemd" ;;
+		*devuan*) b_init="sysvinit" ;;
+		esac
+
+		# Detect variant
+		b_variant="standard"
+		case "${b_tmpl}" in
+		*bnna*) b_variant="bnna" ;;
+		esac
+
+		# Mark default
+		if test -n "${b_default}" && echo "${b_volid}" | grep -qF "${b_default}"; then
+			b_variant="${b_variant},default"
+		fi
+
+		printf '%s\t%s\t%s\t%s\n' "${b_n}" "${b_tmpl}" "${b_init}" "${b_variant}"
+	done
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- 3 skills (`proxmox`, `proxmox-create-vm`, `proxmox-dns`) totaling ~4700 tokens -- fits 32k-context agent budget at ~15%
- 9 shell scripts producing structured TSV output with inline `# AGENT:` hints
- `AGENTS.md` with symlink setup so agents suggest linking into `~/Agents/skills/`
- Reference files: `minimum-permissions.csv` (always available), `apex-domains.md` (loaded on demand)
- Self-improving process: header/footer in index skill prompts agents to note issues and suggest fixes

Covers the full deploy flow: doctor -> scan -> profile -> SSH pre-flight -> template -> create VM -> DNS -> SSH verify.

## Test plan

- [ ] Symlink skills into `~/Agents/skills/` and verify discovery
- [ ] Run full deploy flow end-to-end through an agent session
- [ ] Verify `# AGENT:` hints guide a mid-tier agent through each decision point