### PR TITLE
Respond to agent feedback: TLS timing and pre-create confirmation

### DIFF
--- a/skills/proxmox-create-vm/SKILL.md
+++ b/skills/proxmox-create-vm/SKILL.md
@@ -27,7 +27,11 @@ Present the numbered list to the user. Guide the choice:
 - Prefer: `custom` > `bnna` variant > `standard`
 - The `default` tag marks the env's `PROXMOX_TEMPLATE_DEFAULT`
 
-### Step 3: Run the command
+### Step 3: Confirm before creating
+
+NEVER: Run `proxmox-create` without first presenting the plan to the user (hostname, template, RAM/vCPU/storage, active profile) and receiving explicit confirmation.
+
+### Step 4: Run the command
 
 MUST: Always pass `--os` with a full `vztmpl/...` path.
 
@@ -87,9 +91,11 @@ GW:     10.11.4.1
 
 ## Post-Creation
 
-1. **TLS certificate** -- `proxmox-create` initiates ACME issuance automatically
+1. **TLS certificate** -- `proxmox-create` initiates ACME issuance automatically.
+   TLS issuance continues after `expect eof` returns -- the container is created
+   but SSH via the `tls-` domain won't work until the cert is ready (~10-30s).
 2. **DNS** -- Set up friendly domains (see `proxmox-dns` skill)
-3. **SSH access** -- Wait for container init, then confirm:
+3. **SSH access** -- Wait for container init and TLS cert, then confirm:
 
 ```sh
 sh ~/Agents/skills/proxmox/scripts/proxmox-sh-ssh-wait <direct-ip-domain> [<friendly-domain>]

--- a/skills/proxmox/SKILL.md
+++ b/skills/proxmox/SKILL.md
@@ -6,15 +6,14 @@ description:
   runs the doctor script and points to focused sub-skills.
 ---
 
-**Self-improving process.** As you work through these steps, note anything
-confusing, missing, or wrong -- unclear script output, missing agent hints,
-wrong defaults, steps that should be automated. Collect these as you go.
+**You (the agent)** run all scripts on behalf of the user. Each step produces
+structured output with `# AGENT:` hints -- read them and act accordingly.
+Only escalate to the user on actual roadblocks or decisions that need their input.
+"The user" always means the person you're assisting.
 
 ## End-to-End Workflow
 
-The full deploy flow runs in order. Each step produces structured output with
-`# AGENT:` hints. Run each script, read the hints, and act on them.
-
+0. **Note issues** -- as you go, note anything confusing, missing, or wrong
 1. **Doctor** -- validate environment, check connectivity
 2. **Scan** -- list available pools, VMs, storages, SDN
 3. **Confirm profile** -- pick or confirm the Proxmox account
@@ -23,6 +22,7 @@ The full deploy flow runs in order. Each step produces structured output with
 6. **Create VM** -- provision the LXC container (see `proxmox-create-vm` skill)
 7. **DNS** -- map a friendly domain to the VM (see `proxmox-dns` skill)
 8. **SSH verify** -- confirm SSH access, check DNS propagation
+9. **Review** -- check your notes; suggest updates to scripts or skills
 
 Steps 1-4 are startup/pre-flight. Steps 5-8 are the create flow.
 Not every task needs all steps -- listing VMs only needs 1-3.
@@ -224,8 +224,3 @@ Installed at `~/.local/opt/proxmox-sh/`, commands in `bin/`:
 | `proxmox-sh-update` | Git pull latest proxmox-sh |
 | `caddy-add` | Add reverse proxy routes via Caddy API |
 
-## After Completion
-
-Review your notes from the process. If anything was confusing, missing, or
-wrong -- suggest updates to the scripts or skill files so the next run is
-smoother.

--- a/skills/proxmox/scripts/proxmox-sh-ssh-wait
+++ b/skills/proxmox/scripts/proxmox-sh-ssh-wait
@@ -25,7 +25,9 @@ set -u
 #   0 - SSH ready on direct-IP (friendly domain may have warned)
 #   1 - SSH not ready after retries
 #
-# AGENT: After this script succeeds, present the user a summary table:
+# AGENT: TLS cert issuance continues after proxmox-create exits. If ssh-wait
+#   fails on the first run, wait 30s and retry once -- the cert may still be
+#   issuing. After this script succeeds, present the user a summary table:
 #   CTID, OS, user, direct-IP domain, friendly domain (if set), ssh command.
 #   On DNS WARN: verify the record was created correctly using domainpanel.
 #     - Subdomain: check CNAME points to the tls- direct-IP domain


### PR DESCRIPTION
## Summary

- **TLS timing**: Note that `proxmox-create` initiates ACME cert issuance but it continues after `expect eof` returns. If `proxmox-sh-ssh-wait` is run immediately, it may fail — the retry backoff handles it, but the skill now explains why.
- **Pre-create confirmation**: Add Step 3 requiring the agent to present hostname, template, sizing, and profile to the user and wait for explicit confirmation before running `proxmox-create`. Prevents silently creating VMs with wrong names or in wrong pools.

## Context

Both issues surfaced during a live provisioning run. The agent proceeded straight from template selection to `proxmox-create` without confirming, and then ran `ssh-wait` before TLS was ready, causing two failed attempts.

## Test plan

- [ ] Verify Step 3 (confirm) appears between template selection and `proxmox-create` in the skill
- [ ] Verify Post-Creation section explains TLS issuance timing