### PR TITLE
feat: enable nesting by default for new LXC containers

### DIFF
--- a/bin/proxmox-create
+++ b/bin/proxmox-create
@@ -224,8 +224,7 @@ fn_create_lxc() { (
    my_search_domain="${PROXMOX_SEARCH_DOMAIN:-}"
    my_nameserver="${PROXMOX_NAMESERVER:-}"
    my_bridge="${PROXMOX_VNET:-$PROXMOX_BRIDGE}"
-   #my_features='nesting=1'
-   my_features="" # only non-default values can be set
+   my_features='nesting=1'
 
    my_tmpl_vol="${PROXMOX_TEMPLATE_STORAGE}"
    my_fs_size=8


### PR DESCRIPTION
## Summary
- Enables `nesting=1` feature flag by default when creating LXC containers
- Required for running Docker/Podman and other container runtimes inside LXCs

## Test plan
- [ ] Create a new LXC and verify nesting is enabled in the container config