### PR TITLE
fix: allocate first available container ID instead of highest+1

### DIFF
--- a/bin/proxmox-create
+++ b/bin/proxmox-create
@@ -796,11 +796,24 @@ main() { (
    my_ip_domain="tls-${my_ip_label}.${DIRECT_IP_DOMAIN:-$PROXMOX_ID_PREFIX.$PROXMOX_SEARCH_DOMAIN}"
    my_raw_ip_domain="tcp-${my_ip_label}.${DIRECT_IP_DOMAIN:-$PROXMOX_ID_PREFIX.$PROXMOX_SEARCH_DOMAIN}"
 
-   # Initiate ACME TLS now to avoid confusing browser and/or ssh errors
+   # Poll for TLS readiness — the VM and ACME cert may take a moment
    echo ""
    printf "Waiting for TLS certificate issuance..."
-   if curl -s "https://${my_ip_domain}" > /dev/null; then
-      echo 'done'
+   b_tls_ok=''
+   b_tls_try=0
+   while test "${b_tls_try}" -lt 6; do
+      if curl -s --max-time 5 "https://${my_ip_domain}" > /dev/null 2>&1; then
+         b_tls_ok='1'
+         break
+      fi
+      b_tls_try="$((b_tls_try + 1))"
+      printf "."
+      sleep 5
+   done
+   if test -n "${b_tls_ok}"; then
+      echo "done"
+   else
+      echo "timed out (may still be provisioning)"
    fi
 
    {

--- a/bin/proxmox-create
+++ b/bin/proxmox-create
@@ -78,13 +78,50 @@ else
    my_base_url="https://${PROXMOX_HOST}/api2/json"
 fi
 fn_curl() {
+   b_url="$(fn_curl_last_arg "$@")"
+   b_resp_file="$(mktemp)"
+
+   set +e
    if test -n "${TLS_ROUTER_AUTH:-}"; then
-      curl --max-time 15 --fail-with-body -sSL \
-         -H "X-TLS-Router-Auth: ${TLS_ROUTER_AUTH}" \
-         "$@"
+      b_http_code="$(
+         curl --max-time 15 --fail-with-body -sSL \
+            -H "X-TLS-Router-Auth: ${TLS_ROUTER_AUTH}" \
+            -w '%{http_code}' -o "${b_resp_file}" \
+            "$@"
+      )"
    else
-      curl --max-time 15 --fail-with-body -sSL "$@"
+      b_http_code="$(
+         curl --max-time 15 --fail-with-body -sSL \
+            -w '%{http_code}' -o "${b_resp_file}" \
+            "$@"
+      )"
    fi
+   b_exit=$?
+   set -e
+
+   if test "${b_exit}" -ne 0; then
+      echo "" >&2
+      echo "ERROR: curl request failed" >&2
+      echo "    URL:    ${b_url}" >&2
+      echo "    HTTP:   ${b_http_code}" >&2
+      echo "    curl:   exit ${b_exit}" >&2
+      b_body="$(cat "${b_resp_file}" 2>/dev/null)"
+      rm -f "${b_resp_file}"
+      if test -n "${b_body}"; then
+         echo "    body:   ${b_body}" >&2
+      fi
+      return "${b_exit}"
+   fi
+
+   cat "${b_resp_file}"
+   rm -f "${b_resp_file}"
+}
+
+fn_curl_last_arg() {
+   while test "$#" -gt 1; do
+      shift
+   done
+   echo "${1}"
 }
 
 fn_discover() { (

--- a/bin/proxmox-create
+++ b/bin/proxmox-create
@@ -135,19 +135,20 @@ fn_resources_next_index() { (
       return
    fi
 
-   my_resource_last_id="$(
+   my_used_suffixes="$(
       echo "${my_resource_ids}" |
-         sort -u |
-         tail -n 1
+         while read -r my_rid; do
+            echo "$((my_rid % 1000))"
+         done |
+         sort -n -u
    )"
 
-   # Goal: 1101001 => 2
-   # 0. 1101001 => 1
-   my_resource_index="$((my_resource_last_id % 1000))"
-   # 1. 1 => 2
-   my_resource_index="$((my_resource_index + 1))"
+   my_next="${PROXMOX_ID_START}"
+   while echo "${my_used_suffixes}" | grep -q "^${my_next}$"; do
+      my_next="$((my_next + 1))"
+   done
 
-   echo "${my_resource_index}"
+   echo "${my_next}"
 ); }
 
 fn_ssh_keys() { (


### PR DESCRIPTION
## Summary
- `fn_resources_next_index` previously found the highest VMID with a given prefix and returned suffix + 1, skipping gaps left by deleted containers. Now walks from `PROXMOX_ID_START` upward and returns the first unused suffix, reusing IDs/IPs from deleted containers.
- `fn_curl` now catches failures and prints the URL, HTTP status, and response body to stderr — without leaking auth tokens.

## Test plan
- [ ] Create a container, delete it, create another — verify the deleted ID is reused
- [ ] Verify behavior with no existing containers (should start at `PROXMOX_ID_START`)
- [ ] Verify behavior with no gaps (should return highest + 1, same as before)
- [ ] Trigger a curl failure (e.g. bad URL) — verify error shows URL and HTTP status, no tokens