### PR TITLE
fix: retry TLS readiness check up to 6 times with 5s intervals

### DIFF
--- a/bin/proxmox-create
+++ b/bin/proxmox-create
@@ -758,11 +758,24 @@ main() { (
    my_ip_domain="tls-${my_ip_label}.${DIRECT_IP_DOMAIN:-$PROXMOX_ID_PREFIX.$PROXMOX_SEARCH_DOMAIN}"
    my_raw_ip_domain="tcp-${my_ip_label}.${DIRECT_IP_DOMAIN:-$PROXMOX_ID_PREFIX.$PROXMOX_SEARCH_DOMAIN}"
 
-   # Initiate ACME TLS now to avoid confusing browser and/or ssh errors
+   # Poll for TLS readiness — the VM and ACME cert may take a moment
    echo ""
    printf "Waiting for TLS certificate issuance..."
-   if curl -s "https://${my_ip_domain}" > /dev/null; then
-      echo 'done'
+   b_tls_ok=''
+   b_tls_try=0
+   while test "${b_tls_try}" -lt 6; do
+      if curl -s --max-time 5 "https://${my_ip_domain}" > /dev/null 2>&1; then
+         b_tls_ok='1'
+         break
+      fi
+      b_tls_try="$((b_tls_try + 1))"
+      printf "."
+      sleep 5
+   done
+   if test -n "${b_tls_ok}"; then
+      echo "done"
+   else
+      echo "timed out (may still be provisioning)"
    fi
 
    {

--- a/bin/proxmox-create
+++ b/bin/proxmox-create
@@ -762,13 +762,11 @@ main() { (
    echo ""
    printf "Waiting for TLS certificate issuance..."
    b_tls_ok=''
-   b_tls_try=0
-   while test "${b_tls_try}" -lt 6; do
+   for b_tls_try in 1 2 3 4 5 6; do
       if curl -s --max-time 5 "https://${my_ip_domain}" > /dev/null 2>&1; then
          b_tls_ok='1'
          break
       fi
-      b_tls_try="$((b_tls_try + 1))"
       printf "."
       sleep 5
    done


### PR DESCRIPTION
## Summary
- TLS certificate readiness check now polls up to 6 times with 5-second intervals (30s total)
- Previously was a single fire-and-forget curl that silently failed if the VM wasn't ready
- Prints progress dots while waiting, reports "timed out" if still not ready

## Test plan
- [ ] Create a new container — verify TLS poll shows dots and eventually succeeds
- [ ] Verify timeout message appears if TLS is not ready within 30s