### PR TITLE
docs: add PROXMOX_ID_END to example env

### DIFF
--- a/example.proxmox-sh.env
+++ b/example.proxmox-sh.env
@@ -19,6 +19,8 @@ PROXMOX_TARGET_NODE='pve1'
 PROXMOX_ID_PREFIX='1100'
 # MUST be at least 2 (used as VMID and IP address)
 PROXMOX_ID_START='51'
+# MUST be at most 254 (default 249)
+PROXMOX_ID_END='249'
 PROXMOX_RESOURCE_POOL='ex1-dev'
 PROXMOX_TEMPLATE_STORAGE='cephfs0'
 PROXMOX_TEMPLATE_DEFAULT='vztmpl/devuan-5.0-standard_5.0_amd64.tar.gz'


### PR DESCRIPTION
## Summary
- Add `PROXMOX_ID_END` to `example.proxmox-sh.env` to match the new env var added in #70

## Test plan
- [x] Matches the default value (249) and comment style of `PROXMOX_ID_START`